### PR TITLE
Update bs aeson

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## 0.9.0.0 -- 2018-06-03
 
-* Output BuckleScript code requires at least BuckleScript 3.1.0.
+* Output BuckleScript code requires at least bs-platform 3.1.0.
 * Change output BuckleScript code and test code to use `Belt.Result.t` instead of `Js.Result.t`. `Js.Result.t` has been deprecated since BuckleScript 3.1.0.
 * Add `OInt32` to `OCaml.BuckleScript.Types.OCamlPrimitive` to convert Haskell `Int32` to BuckleScript `int32`.
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,7 +3,7 @@
 ## 0.9.0.0 -- 2018-06-03
 
 * Output BuckleScript code requires at least bs-platform 3.1.0.
-* Change output BuckleScript code and test code to use `Belt.Result.t` instead of `Js.Result.t`. `Js.Result.t` has been deprecated since BuckleScript 3.1.0.
+* Change output BuckleScript code and test code to use `Belt.Result.t` instead of `Js.Result.t`. `Js.Result.t` has been deprecated since bs-platform 3.1.0.
 * Add `OInt32` to `OCaml.BuckleScript.Types.OCamlPrimitive` to convert Haskell `Int32` to BuckleScript `int32`.
 
 ## 0.8.0.0 -- 2018-05-03

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
 # Revision history for ocaml-export
 
+## 0.9.0.0 -- 2018-06-03
+
+* Output BuckleScript code requires at least BuckleScript 3.1.0.
+* Change output BuckleScript code and test code to use `Belt.Result.t` instead of `Js.Result.t`. `Js.Result.t` has been deprecated since BuckleScript 3.1.0.
+* Add `OInt32` to `OCaml.BuckleScript.Types.OCamlPrimitive` to convert Haskell `Int32` to BuckleScript `int32`.
+
 ## 0.8.0.0 -- 2018-05-03
 
 * Support GHC 8.2.2 and drop support for previous GHC versions. 'base >= 4.10' is a requirement.

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: ocaml-export
-version: 0.8.0.0
+version: 0.9.0.0
 synopsis: Convert Haskell types in OCaml types
 description: Use GHC.Generics and Typeable to convert Haskell types to OCaml types. Convert aeson serialization to ocaml.
 category: Web

--- a/src/OCaml/BuckleScript/Decode.hs
+++ b/src/OCaml/BuckleScript/Decode.hs
@@ -548,3 +548,17 @@ unwrapIfTypeParameter (OCamlTypeParameterRef _) doc = parens $ "fun a -> unwrapR
 unwrapIfTypeParameter (OCamlRef _ _) doc = parens $ "fun a -> unwrapResult" <+> (parens $ doc <+> "a")
 unwrapIfTypeParameter (OCamlRefApp _ _) doc = parens $ "fun a -> unwrapResult" <+> (parens $ doc <+> "a")
 unwrapIfTypeParameter _ doc = doc
+
+
+{-
+let int642 = [%raw {|
+  function(a) {
+    return ((((int64_t) a[0]) << 32) | a[1]);
+  }
+|}]
+
+split 64 bit int into two values
+  output_values[0] = (input_value >> 32) & 0xffffffff;
+  output_values[1] = input_value & 0xffffffff;
+
+-}

--- a/src/OCaml/BuckleScript/Decode.hs
+++ b/src/OCaml/BuckleScript/Decode.hs
@@ -549,17 +549,3 @@ unwrapIfTypeParameter (OCamlTypeParameterRef _) doc = parens $ "fun a -> unwrapR
 unwrapIfTypeParameter (OCamlRef _ _) doc = parens $ "fun a -> unwrapResult" <+> (parens $ doc <+> "a")
 unwrapIfTypeParameter (OCamlRefApp _ _) doc = parens $ "fun a -> unwrapResult" <+> (parens $ doc <+> "a")
 unwrapIfTypeParameter _ doc = doc
-
-
-{-
-let int642 = [%raw {|
-  function(a) {
-    return ((((int64_t) a[0]) << 32) | a[1]);
-  }
-|}]
-
-split 64 bit int into two values
-  output_values[0] = (input_value >> 32) & 0xffffffff;
-  output_values[1] = input_value & 0xffffffff;
-
--}

--- a/src/OCaml/BuckleScript/Encode.hs
+++ b/src/OCaml/BuckleScript/Encode.hs
@@ -301,6 +301,7 @@ instance HasEncoderRef OCamlPrimitive where
   renderRef ODate   = pure "Aeson.Encode.date"
   renderRef OFloat  = pure "Aeson.Encode.float"
   renderRef OInt    = pure "Aeson.Encode.int"
+  renderRef OInt32  = pure "Aeson.Encode.int32"
   renderRef OString = pure "Aeson.Encode.string"
   renderRef OUnit   = pure "Aeson.Encode.null"
 
@@ -314,10 +315,10 @@ instance HasEncoderRef OCamlPrimitive where
     dd <- renderRef datatype
     pure . parens $ "Aeson.Encode.optional" <+> dd
 
-  renderRef (OEither t0 t1) = do
-    dt0 <- renderRef t0
-    dt1 <- renderRef t1
-    pure . parens $ "Aeson.Encode.either" <+> dt0 <+> dt1
+  renderRef (OEither l r) = do
+    dl <- renderRef l
+    dr <- renderRef r
+    pure . parens $ "Aeson.Encode.either" <+> dl <+> dr
 
   renderRef (OTuple2 t0 t1) = do
     dt0 <- renderRef t0

--- a/src/OCaml/BuckleScript/Record.hs
+++ b/src/OCaml/BuckleScript/Record.hs
@@ -230,7 +230,7 @@ instance HasTypeRef OCamlPrimitive where
   renderRef (OEither l r) = do
     dl <- renderRef l
     dr <- renderRef r
-    pure $ (parens $ dr <> comma <+> dl) <+> "Belt.Result.t"
+    pure $ (parens $ dl <> comma <+> dr) <+> "Aeson.Compatibility.Either.t"
 
   renderRef (OTuple2 a b) = do
     da <- renderRef a

--- a/src/OCaml/BuckleScript/Record.hs
+++ b/src/OCaml/BuckleScript/Record.hs
@@ -213,6 +213,7 @@ instance HasTypeRef OCamlPrimitive where
   renderRef ODate   = pure "Js_date.t"
   renderRef OFloat  = pure "float"
   renderRef OInt    = pure "int"
+  renderRef OInt32  = pure "int32"
   renderRef OString = pure "string"
   renderRef OUnit   = pure "unit"
 
@@ -226,10 +227,10 @@ instance HasTypeRef OCamlPrimitive where
     dt <- renderRef datatype
     pure $ parens dt <+> "option"
 
-  renderRef (OEither k v) = do
-    dk <- renderRef k
-    dv <- renderRef v
-    pure $ (parens $ dk <> comma <+> dv) <+> "Aeson.Compatibility.Either.t"
+  renderRef (OEither l r) = do
+    dl <- renderRef l
+    dr <- renderRef r
+    pure $ (parens $ dr <> comma <+> dl) <+> "Belt.Result.t"
 
   renderRef (OTuple2 a b) = do
     da <- renderRef a

--- a/src/OCaml/BuckleScript/Types.hs
+++ b/src/OCaml/BuckleScript/Types.hs
@@ -118,11 +118,12 @@ data OCamlPrimitive
   | ODate -- ^ Js_date.t
   | OFloat -- ^ float
   | OInt -- ^ int
+  | OInt32 -- ^ int32
   | OString -- ^ string
   | OUnit -- ^ ()
   | OList OCamlDatatype -- ^ 'a list, 'a Js_array.t
   | OOption OCamlDatatype -- ^ 'a option
-  | OEither OCamlDatatype OCamlDatatype -- ^ 'l 'r Aeson.Compatibility.Either.t
+  | OEither OCamlDatatype OCamlDatatype -- ^ 'r 'l Belt.Result.t
   | OTuple2 OCamlDatatype OCamlDatatype -- ^ (*)
   | OTuple3 OCamlDatatype OCamlDatatype OCamlDatatype -- ^ (**)
   | OTuple4 OCamlDatatype OCamlDatatype OCamlDatatype OCamlDatatype -- ^ (***)

--- a/src/OCaml/BuckleScript/Types.hs
+++ b/src/OCaml/BuckleScript/Types.hs
@@ -324,7 +324,7 @@ primitiveTypeRepToOCamlPrimitive t =
       [ ( typeRepTyCon $ typeRep (Proxy :: Proxy Int), OInt)
       , ( typeRepTyCon $ typeRep (Proxy :: Proxy Int8), OInt)
       , ( typeRepTyCon $ typeRep (Proxy :: Proxy Int16), OInt)
-      , ( typeRepTyCon $ typeRep (Proxy :: Proxy Int32), OInt)
+      , ( typeRepTyCon $ typeRep (Proxy :: Proxy Int32), OInt32)
       , ( typeRepTyCon $ typeRep (Proxy :: Proxy Int64), OInt)
       , ( typeRepTyCon $ typeRep (Proxy :: Proxy Integer), OInt)
       , ( typeRepTyCon $ typeRep (Proxy :: Proxy Word), OInt)

--- a/src/OCaml/BuckleScript/Types.hs
+++ b/src/OCaml/BuckleScript/Types.hs
@@ -123,7 +123,7 @@ data OCamlPrimitive
   | OUnit -- ^ ()
   | OList OCamlDatatype -- ^ 'a list, 'a Js_array.t
   | OOption OCamlDatatype -- ^ 'a option
-  | OEither OCamlDatatype OCamlDatatype -- ^ 'r 'l Belt.Result.t
+  | OEither OCamlDatatype OCamlDatatype -- ^ 'l 'r Aeson.Compatibility.Either.t
   | OTuple2 OCamlDatatype OCamlDatatype -- ^ (*)
   | OTuple3 OCamlDatatype OCamlDatatype OCamlDatatype -- ^ (**)
   | OTuple4 OCamlDatatype OCamlDatatype OCamlDatatype OCamlDatatype -- ^ (***)
@@ -448,7 +448,7 @@ instance OCamlType Int16 where
   toOCamlType _ = OCamlPrimitive OInt
 
 instance OCamlType Int32 where
-  toOCamlType _ = OCamlPrimitive OInt
+  toOCamlType _ = OCamlPrimitive OInt32
 
 instance OCamlType Int64 where
   toOCamlType _ = OCamlPrimitive OInt

--- a/test/interface/golden/file/File.ml
+++ b/test/interface/golden/file/File.ml
@@ -15,8 +15,8 @@ let decodePerson json =
     ; name = optional (field "name" string) json
     }
   with
-  | v -> Js_result.Ok v
-  | exception Aeson.Decode.DecodeError message -> Js_result.Error ("decodePerson: " ^ message)
+  | v -> Belt.Result.Ok v
+  | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("decodePerson: " ^ message)
 
 
 type automobile =
@@ -39,8 +39,8 @@ let decodeAutomobile json =
     ; year = field "year" int json
     }
   with
-  | v -> Js_result.Ok v
-  | exception Aeson.Decode.DecodeError message -> Js_result.Error ("decodeAutomobile: " ^ message)
+  | v -> Belt.Result.Ok v
+  | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("decodeAutomobile: " ^ message)
 
 type business =
   { taxId : string
@@ -65,8 +65,8 @@ let decodeBusiness json =
     ; companyVehicle = optional (field "companyVehicle" (fun a -> unwrapResult (decodeAutomobile a))) json
     }
   with
-  | v -> Js_result.Ok v
-  | exception Aeson.Decode.DecodeError message -> Js_result.Error ("decodeBusiness: " ^ message)
+  | v -> Belt.Result.Ok v
+  | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("decodeBusiness: " ^ message)
 
 
 type ('a, 'b) wrapper =
@@ -89,8 +89,8 @@ let decodeWrapper a b json =
         ; wrapperC = field "wrapperC" string json
         }
   with
-  | v -> Js_result.Ok v
-  | exception Aeson.Decode.DecodeError message -> Js_result.Error ("decodeWrapper: " ^ message)
+  | v -> Belt.Result.Ok v
+  | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("decodeWrapper: " ^ message)
 
 
 type autoDependingOnManual =
@@ -110,8 +110,8 @@ let decodeAutoDependingOnManual json =
     ; bbBusiness = field "bbBusiness" (fun a -> unwrapResult (decodeBusiness a)) json
     }
   with
-  | v -> Js_result.Ok v
-  | exception Aeson.Decode.DecodeError message -> Js_result.Error ("decodeAutoDependingOnManual: " ^ message)
+  | v -> Belt.Result.Ok v
+  | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("decodeAutoDependingOnManual: " ^ message)
 
 type nonGenericType =
   { ngA : string
@@ -130,6 +130,6 @@ let decodeNonGenericType json =
         ; ngB = field "ngB" int json
         }
   with
-  | v -> Js_result.Ok v
-  | exception Aeson.Decode.DecodeError message -> Js_result.Error ("decodeNonGenericType: " ^ message)
+  | v -> Belt.Result.Ok v
+  | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("decodeNonGenericType: " ^ message)
 

--- a/test/interface/golden/file/File.mli
+++ b/test/interface/golden/file/File.mli
@@ -5,7 +5,7 @@ type person =
 
 val encodePerson : person -> Js_json.t
 
-val decodePerson : Js_json.t -> (person, string) Js_result.t
+val decodePerson : Js_json.t -> (person, string) Belt.Result.t
 
 
 type automobile =
@@ -16,7 +16,7 @@ type automobile =
 
 val encodeAutomobile : automobile -> Js_json.t
 
-val decodeAutomobile : Js_json.t -> (automobile, string) Js_result.t
+val decodeAutomobile : Js_json.t -> (automobile, string) Belt.Result.t
 
 type business =
   { taxId : string
@@ -27,7 +27,7 @@ type business =
 
 val encodeBusiness : business -> Js_json.t
 
-val decodeBusiness : Js_json.t -> (business, string) Js_result.t
+val decodeBusiness : Js_json.t -> (business, string) Belt.Result.t
 
 
 type ('a, 'b) wrapper =
@@ -38,7 +38,7 @@ type ('a, 'b) wrapper =
 
 val encodeWrapper : ('a -> Js_json.t) -> ('b -> Js_json.t) -> ('a, 'b) wrapper -> Js_json.t
 
-val decodeWrapper : (Js_json.t -> ('a, string) Js_result.t) -> (Js_json.t -> ('b, string) Js_result.t) -> Js_json.t -> (('a, 'b) wrapper, string) Js_result.t
+val decodeWrapper : (Js_json.t -> ('a, string) Belt.Result.t) -> (Js_json.t -> ('b, string) Belt.Result.t) -> Js_json.t -> (('a, 'b) wrapper, string) Belt.Result.t
 
 
 type autoDependingOnManual =
@@ -48,7 +48,7 @@ type autoDependingOnManual =
 
 val encodeAutoDependingOnManual : autoDependingOnManual -> Js_json.t
 
-val decodeAutoDependingOnManual : Js_json.t -> (autoDependingOnManual, string) Js_result.t
+val decodeAutoDependingOnManual : Js_json.t -> (autoDependingOnManual, string) Belt.Result.t
 
 type nonGenericType =
   { ngA : string
@@ -57,5 +57,5 @@ type nonGenericType =
 
 val encodeNonGenericType : nonGenericType -> Js_json.t
 
-val decodeNonGenericType : Js_json.t -> (nonGenericType, string) Js_result.t
+val decodeNonGenericType : Js_json.t -> (nonGenericType, string) Belt.Result.t
 

--- a/test/interface/golden/package.json
+++ b/test/interface/golden/package.json
@@ -14,7 +14,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "bs-aeson": "^2.0.0"
+    "bs-aeson": "github:plow-technologies/bs-aeson#8eed965c4841c5788ebf40a22c7df3aafcaa5749"
   },
   "devDependencies": {
     "bs-aeson-spec": "^2.0.0",

--- a/test/interface/golden/package.json
+++ b/test/interface/golden/package.json
@@ -14,11 +14,11 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "bs-aeson": "github:plow-technologies/bs-aeson#8eed965c4841c5788ebf40a22c7df3aafcaa5749"
+    "bs-aeson": "^3.0.0"
   },
   "devDependencies": {
     "bs-aeson-spec": "^2.0.0",
-    "bs-platform": "^3.1.3",
+    "bs-platform": "^3.1.5",
     "@glennsl/bs-jest": "^0.4.2",
     "bs-node": "github:buckletypes/bs-node"
   }

--- a/test/interface/golden/package.json
+++ b/test/interface/golden/package.json
@@ -8,21 +8,18 @@
     "build": "bsb -make-world",
     "start": "bsb -make-world -w",
     "clean": "bsb -clean-world",
-    "test": "npm run build && jest",
-    "watch:bsb": "bsb -make-world -w",
-    "watch:jest": "jest --watchAll",
-    "watch:screen": "screen -c .screenrc"
+    "test": "npm run build && jest"
   },
   "keywords": [],
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "bs-aeson": "^1.1.0",
-    "bs-platform": "^2.2.0"
+    "bs-aeson": "^2.0.0"
   },
   "devDependencies": {
-    "bs-aeson-spec": "^1.2.1",
-    "@glennsl/bs-jest": "^0.4.1",
+    "bs-aeson-spec": "^2.0.0",
+    "bs-platform": "^3.1.3",
+    "@glennsl/bs-jest": "^0.4.2",
     "bs-node": "github:buckletypes/bs-node"
   }
 }

--- a/test/interface/golden/product/Card.ml
+++ b/test/interface/golden/product/Card.ml
@@ -17,12 +17,12 @@ let encodeSuit x =
 
 let decodeSuit json =
   match Js_json.decodeString json with
-  | Some "Clubs" -> Js_result.Ok Clubs
-  | Some "Diamonds" -> Js_result.Ok Diamonds
-  | Some "Hearts" -> Js_result.Ok Hearts
-  | Some "Spades" -> Js_result.Ok Spades
-  | Some err -> Js_result.Error ("decodeSuit: unknown enumeration '" ^ err ^ "'.")
-  | None -> Js_result.Error "decodeSuit: expected a top-level JSON string."
+  | Some "Clubs" -> Belt.Result.Ok Clubs
+  | Some "Diamonds" -> Belt.Result.Ok Diamonds
+  | Some "Hearts" -> Belt.Result.Ok Hearts
+  | Some "Spades" -> Belt.Result.Ok Spades
+  | Some err -> Belt.Result.Error ("decodeSuit: unknown enumeration '" ^ err ^ "'.")
+  | None -> Belt.Result.Error "decodeSuit: expected a top-level JSON string."
 
 type card =
   { cardSuit : suit
@@ -41,5 +41,5 @@ let decodeCard json =
     ; cardValue = field "cardValue" int json
     }
   with
-  | v -> Js_result.Ok v
-  | exception Aeson.Decode.DecodeError message -> Js_result.Error ("decodeCard: " ^ message)
+  | v -> Belt.Result.Ok v
+  | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("decodeCard: " ^ message)

--- a/test/interface/golden/product/Card.mli
+++ b/test/interface/golden/product/Card.mli
@@ -6,7 +6,7 @@ type suit =
 
 val encodeSuit : suit -> Js_json.t
 
-val decodeSuit : Js_json.t -> (suit, string) Js_result.t
+val decodeSuit : Js_json.t -> (suit, string) Belt.Result.t
 
 type card =
   { cardSuit : suit
@@ -15,4 +15,4 @@ type card =
 
 val encodeCard : card -> Js_json.t
 
-val decodeCard : Js_json.t -> (card, string) Js_result.t
+val decodeCard : Js_json.t -> (card, string) Belt.Result.t

--- a/test/interface/golden/product/Company.ml
+++ b/test/interface/golden/product/Company.ml
@@ -15,5 +15,5 @@ let decodeCompany json =
     ; employees = field "employees" (list (fun a -> unwrapResult (Person.decodePerson a))) json
     }
   with
-  | v -> Js_result.Ok v
-  | exception Aeson.Decode.DecodeError message -> Js_result.Error ("decodeCompany: " ^ message)
+  | v -> Belt.Result.Ok v
+  | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("decodeCompany: " ^ message)

--- a/test/interface/golden/product/Company.mli
+++ b/test/interface/golden/product/Company.mli
@@ -5,4 +5,4 @@ type company =
 
 val encodeCompany : company -> Js_json.t
 
-val decodeCompany : Js_json.t -> (company, string) Js_result.t
+val decodeCompany : Js_json.t -> (company, string) Belt.Result.t

--- a/test/interface/golden/product/ComplexProduct.ml
+++ b/test/interface/golden/product/ComplexProduct.ml
@@ -15,16 +15,16 @@ let decodeSimple json =
     ; sb = field "sb" string json
     }
   with
-  | v -> Js_result.Ok v
-  | exception Aeson.Decode.DecodeError message -> Js_result.Error ("decodeSimple: " ^ message)
+  | v -> Belt.Result.Ok v
+  | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("decodeSimple: " ^ message)
 
 
 type complexProduct =
-  { cp0 : (Person.person, (int) list) Aeson.Compatibility.Either.t
-  ; cp1 : ((int * (string, float) Aeson.Compatibility.Either.t)) list
+  { cp0 : ((int) list, Person.person) Belt.Result.t
+  ; cp1 : ((int * (float, string) Belt.Result.t)) list
   ; cp2 : ((int) list) list
   ; cp3 : ((int) list) option
-  ; cp4 : (simple, int) Aeson.Compatibility.Either.t
+  ; cp4 : (int, simple) Belt.Result.t
   }
 
 let encodeComplexProduct x =
@@ -45,5 +45,5 @@ let decodeComplexProduct json =
     ; cp4 = field "cp4" (either (fun a -> unwrapResult (decodeSimple a)) int) json
     }
   with
-  | v -> Js_result.Ok v
-  | exception Aeson.Decode.DecodeError message -> Js_result.Error ("decodeComplexProduct: " ^ message)
+  | v -> Belt.Result.Ok v
+  | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("decodeComplexProduct: " ^ message)

--- a/test/interface/golden/product/ComplexProduct.ml
+++ b/test/interface/golden/product/ComplexProduct.ml
@@ -20,11 +20,11 @@ let decodeSimple json =
 
 
 type complexProduct =
-  { cp0 : ((int) list, Person.person) Belt.Result.t
-  ; cp1 : ((int * (float, string) Belt.Result.t)) list
+  { cp0 : (Person.person, (int) list) Aeson.Compatibility.Either.t
+  ; cp1 : ((int * (string, float) Aeson.Compatibility.Either.t)) list
   ; cp2 : ((int) list) list
   ; cp3 : ((int) list) option
-  ; cp4 : (int, simple) Belt.Result.t
+  ; cp4 : (simple, int) Aeson.Compatibility.Either.t
   }
 
 let encodeComplexProduct x =

--- a/test/interface/golden/product/ComplexProduct.mli
+++ b/test/interface/golden/product/ComplexProduct.mli
@@ -5,17 +5,17 @@ type simple =
 
 val encodeSimple : simple -> Js_json.t
 
-val decodeSimple : Js_json.t -> (simple, string) Js_result.t
+val decodeSimple : Js_json.t -> (simple, string) Belt.Result.t
 
 
 type complexProduct =
-  { cp0 : (Person.person, (int) list) Aeson.Compatibility.Either.t
-  ; cp1 : ((int * (string, float) Aeson.Compatibility.Either.t)) list
+  { cp0 : ((int) list, Person.person) Belt.Result.t
+  ; cp1 : ((int * (float, string) Belt.Result.t)) list
   ; cp2 : ((int) list) list
   ; cp3 : ((int) list) option
-  ; cp4 : (simple, int) Aeson.Compatibility.Either.t
+  ; cp4 : (int, simple) Belt.Result.t
   }
 
 val encodeComplexProduct : complexProduct -> Js_json.t
 
-val decodeComplexProduct : Js_json.t -> (complexProduct, string) Js_result.t
+val decodeComplexProduct : Js_json.t -> (complexProduct, string) Belt.Result.t

--- a/test/interface/golden/product/ComplexProduct.mli
+++ b/test/interface/golden/product/ComplexProduct.mli
@@ -9,11 +9,11 @@ val decodeSimple : Js_json.t -> (simple, string) Belt.Result.t
 
 
 type complexProduct =
-  { cp0 : ((int) list, Person.person) Belt.Result.t
-  ; cp1 : ((int * (float, string) Belt.Result.t)) list
+  { cp0 : (Person.person, (int) list) Aeson.Compatibility.Either.t
+  ; cp1 : ((int * (string, float) Aeson.Compatibility.Either.t)) list
   ; cp2 : ((int) list) list
   ; cp3 : ((int) list) option
-  ; cp4 : (int, simple) Belt.Result.t
+  ; cp4 : (simple, int) Aeson.Compatibility.Either.t
   }
 
 val encodeComplexProduct : complexProduct -> Js_json.t

--- a/test/interface/golden/product/CustomOption.ml
+++ b/test/interface/golden/product/CustomOption.ml
@@ -15,5 +15,5 @@ let decodeCompany2 json =
     ; boss = optional (field "boss" (fun a -> unwrapResult (Person.decodePerson a))) json
     }
   with
-  | v -> Js_result.Ok v
-  | exception Aeson.Decode.DecodeError message -> Js_result.Error ("decodeCompany2: " ^ message)
+  | v -> Belt.Result.Ok v
+  | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("decodeCompany2: " ^ message)

--- a/test/interface/golden/product/CustomOption.mli
+++ b/test/interface/golden/product/CustomOption.mli
@@ -5,4 +5,4 @@ type company2 =
 
 val encodeCompany2 : company2 -> Js_json.t
 
-val decodeCompany2 : Js_json.t -> (company2, string) Js_result.t
+val decodeCompany2 : Js_json.t -> (company2, string) Belt.Result.t

--- a/test/interface/golden/product/OneTypeParameter.ml
+++ b/test/interface/golden/product/OneTypeParameter.ml
@@ -15,5 +15,5 @@ let decodeOneTypeParameter decodeA0 json =
     ; otpFirst = field "otpFirst" (fun a -> unwrapResult (decodeA0 a)) json
     }
   with
-  | v -> Js_result.Ok v
-  | exception Aeson.Decode.DecodeError message -> Js_result.Error ("decodeOneTypeParameter: " ^ message)
+  | v -> Belt.Result.Ok v
+  | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("decodeOneTypeParameter: " ^ message)

--- a/test/interface/golden/product/OneTypeParameter.mli
+++ b/test/interface/golden/product/OneTypeParameter.mli
@@ -5,4 +5,4 @@ type 'a0 oneTypeParameter =
 
 val encodeOneTypeParameter : ('a0 -> Js_json.t) -> 'a0 oneTypeParameter -> Js_json.t
 
-val decodeOneTypeParameter : (Js_json.t -> ('a0, string) Js_result.t) -> Js_json.t -> ('a0 oneTypeParameter, string) Js_result.t
+val decodeOneTypeParameter : (Js_json.t -> ('a0, string) Belt.Result.t) -> Js_json.t -> ('a0 oneTypeParameter, string) Belt.Result.t

--- a/test/interface/golden/product/Person.ml
+++ b/test/interface/golden/product/Person.ml
@@ -18,5 +18,5 @@ let decodePerson json =
     ; created = field "created" date json
     }
   with
-  | v -> Js_result.Ok v
-  | exception Aeson.Decode.DecodeError message -> Js_result.Error ("decodePerson: " ^ message)
+  | v -> Belt.Result.Ok v
+  | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("decodePerson: " ^ message)

--- a/test/interface/golden/product/Person.mli
+++ b/test/interface/golden/product/Person.mli
@@ -6,4 +6,4 @@ type person =
 
 val encodePerson : person -> Js_json.t
 
-val decodePerson : Js_json.t -> (person, string) Js_result.t
+val decodePerson : Js_json.t -> (person, string) Belt.Result.t

--- a/test/interface/golden/product/SimpleChoice.ml
+++ b/test/interface/golden/product/SimpleChoice.ml
@@ -1,5 +1,5 @@
 type simpleChoice =
-  { choice : (int, string) Belt.Result.t
+  { choice : (string, int) Aeson.Compatibility.Either.t
   }
 
 let encodeSimpleChoice x =

--- a/test/interface/golden/product/SimpleChoice.ml
+++ b/test/interface/golden/product/SimpleChoice.ml
@@ -1,5 +1,5 @@
 type simpleChoice =
-  { choice : (string, int) Aeson.Compatibility.Either.t
+  { choice : (int, string) Belt.Result.t
   }
 
 let encodeSimpleChoice x =
@@ -12,5 +12,5 @@ let decodeSimpleChoice json =
     { choice = field "choice" (either string int) json
     }
   with
-  | v -> Js_result.Ok v
-  | exception Aeson.Decode.DecodeError message -> Js_result.Error ("decodeSimpleChoice: " ^ message)
+  | v -> Belt.Result.Ok v
+  | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("decodeSimpleChoice: " ^ message)

--- a/test/interface/golden/product/SimpleChoice.mli
+++ b/test/interface/golden/product/SimpleChoice.mli
@@ -1,7 +1,7 @@
 type simpleChoice =
-  { choice : (string, int) Aeson.Compatibility.Either.t
+  { choice : (int, string) Belt.Result.t
   }
 
 val encodeSimpleChoice : simpleChoice -> Js_json.t
 
-val decodeSimpleChoice : Js_json.t -> (simpleChoice, string) Js_result.t
+val decodeSimpleChoice : Js_json.t -> (simpleChoice, string) Belt.Result.t

--- a/test/interface/golden/product/SimpleChoice.mli
+++ b/test/interface/golden/product/SimpleChoice.mli
@@ -1,5 +1,5 @@
 type simpleChoice =
-  { choice : (int, string) Belt.Result.t
+  { choice : (string, int) Aeson.Compatibility.Either.t
   }
 
 val encodeSimpleChoice : simpleChoice -> Js_json.t

--- a/test/interface/golden/product/SubTypeParameter.ml
+++ b/test/interface/golden/product/SubTypeParameter.ml
@@ -18,5 +18,5 @@ let decodeSubTypeParameter decodeA0 decodeA1 decodeA2 json =
     ; tupleC = field "tupleC" (pair (fun a -> unwrapResult (decodeA2 a)) (fun a -> unwrapResult (decodeA1 a))) json
     }
   with
-  | v -> Js_result.Ok v
-  | exception Aeson.Decode.DecodeError message -> Js_result.Error ("decodeSubTypeParameter: " ^ message)
+  | v -> Belt.Result.Ok v
+  | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("decodeSubTypeParameter: " ^ message)

--- a/test/interface/golden/product/SubTypeParameter.mli
+++ b/test/interface/golden/product/SubTypeParameter.mli
@@ -6,4 +6,4 @@ type ('a0, 'a1, 'a2) subTypeParameter =
 
 val encodeSubTypeParameter : ('a0 -> Js_json.t) -> ('a1 -> Js_json.t) -> ('a2 -> Js_json.t) -> ('a0, 'a1, 'a2) subTypeParameter -> Js_json.t
 
-val decodeSubTypeParameter : (Js_json.t -> ('a0, string) Js_result.t) -> (Js_json.t -> ('a1, string) Js_result.t) -> (Js_json.t -> ('a2, string) Js_result.t) -> Js_json.t -> (('a0, 'a1, 'a2) subTypeParameter, string) Js_result.t
+val decodeSubTypeParameter : (Js_json.t -> ('a0, string) Belt.Result.t) -> (Js_json.t -> ('a1, string) Belt.Result.t) -> (Js_json.t -> ('a2, string) Belt.Result.t) -> Js_json.t -> (('a0, 'a1, 'a2) subTypeParameter, string) Belt.Result.t

--- a/test/interface/golden/product/ThreeTypeParameters.ml
+++ b/test/interface/golden/product/ThreeTypeParameters.ml
@@ -24,5 +24,5 @@ let decodeThree decodeA0 decodeA1 decodeA2 json =
     ; threeString = field "threeString" string json
     }
   with
-  | v -> Js_result.Ok v
-  | exception Aeson.Decode.DecodeError message -> Js_result.Error ("decodeThree: " ^ message)
+  | v -> Belt.Result.Ok v
+  | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("decodeThree: " ^ message)

--- a/test/interface/golden/product/ThreeTypeParameters.mli
+++ b/test/interface/golden/product/ThreeTypeParameters.mli
@@ -8,4 +8,4 @@ type ('a0, 'a1, 'a2) three =
 
 val encodeThree : ('a0 -> Js_json.t) -> ('a1 -> Js_json.t) -> ('a2 -> Js_json.t) -> ('a0, 'a1, 'a2) three -> Js_json.t
 
-val decodeThree : (Js_json.t -> ('a0, string) Js_result.t) -> (Js_json.t -> ('a1, string) Js_result.t) -> (Js_json.t -> ('a2, string) Js_result.t) -> Js_json.t -> (('a0, 'a1, 'a2) three, string) Js_result.t
+val decodeThree : (Js_json.t -> ('a0, string) Belt.Result.t) -> (Js_json.t -> ('a1, string) Belt.Result.t) -> (Js_json.t -> ('a2, string) Belt.Result.t) -> Js_json.t -> (('a0, 'a1, 'a2) three, string) Belt.Result.t

--- a/test/interface/golden/product/TwoTypeParameters.ml
+++ b/test/interface/golden/product/TwoTypeParameters.ml
@@ -21,5 +21,5 @@ let decodeTwoTypeParameters decodeA0 decodeA1 json =
     ; ttpThird = field "ttpThird" (pair (fun a -> unwrapResult (decodeA0 a)) (fun a -> unwrapResult (decodeA1 a))) json
     }
   with
-  | v -> Js_result.Ok v
-  | exception Aeson.Decode.DecodeError message -> Js_result.Error ("decodeTwoTypeParameters: " ^ message)
+  | v -> Belt.Result.Ok v
+  | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("decodeTwoTypeParameters: " ^ message)

--- a/test/interface/golden/product/TwoTypeParameters.mli
+++ b/test/interface/golden/product/TwoTypeParameters.mli
@@ -7,4 +7,4 @@ type ('a0, 'a1) twoTypeParameters =
 
 val encodeTwoTypeParameters : ('a0 -> Js_json.t) -> ('a1 -> Js_json.t) -> ('a0, 'a1) twoTypeParameters -> Js_json.t
 
-val decodeTwoTypeParameters : (Js_json.t -> ('a0, string) Js_result.t) -> (Js_json.t -> ('a1, string) Js_result.t) -> Js_json.t -> (('a0, 'a1) twoTypeParameters, string) Js_result.t
+val decodeTwoTypeParameters : (Js_json.t -> ('a0, string) Belt.Result.t) -> (Js_json.t -> ('a1, string) Belt.Result.t) -> Js_json.t -> (('a0, 'a1) twoTypeParameters, string) Belt.Result.t

--- a/test/interface/golden/product/UnnamedProduct.ml
+++ b/test/interface/golden/product/UnnamedProduct.ml
@@ -13,9 +13,9 @@ let decodeUnnamedProduct json =
       | v0 ->
          (match Aeson.Decode.int v.(1) with
           | v1 ->
-             Js_result.Ok (UnnamedProduct (v0, v1))
-          | exception Aeson.Decode.DecodeError message -> Js_result.Error ("UnnamedProduct: " ^ message)
+             Belt.Result.Ok (UnnamedProduct (v0, v1))
+          | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("UnnamedProduct: " ^ message)
          )
-      | exception Aeson.Decode.DecodeError message -> Js_result.Error ("UnnamedProduct: " ^ message)
+      | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("UnnamedProduct: " ^ message)
      )
-  | None -> Js_result.Error ("UnnamedProduct expected an array.")
+  | None -> Belt.Result.Error ("UnnamedProduct expected an array.")

--- a/test/interface/golden/product/UnnamedProduct.mli
+++ b/test/interface/golden/product/UnnamedProduct.mli
@@ -3,4 +3,4 @@ type unnamedProduct =
 
 val encodeUnnamedProduct : unnamedProduct -> Js_json.t
 
-val decodeUnnamedProduct : Js_json.t -> (unnamedProduct, string) Js_result.t
+val decodeUnnamedProduct : Js_json.t -> (unnamedProduct, string) Belt.Result.t

--- a/test/interface/golden/product/Wrapper.ml
+++ b/test/interface/golden/product/Wrapper.ml
@@ -50,7 +50,7 @@ let decodeMaybeWrapped json =
   | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("decodeMaybeWrapped: " ^ message)
 
 type eitherWrapped =
-  { ew : ((float, int) Belt.Result.t) wrapper
+  { ew : ((int, float) Aeson.Compatibility.Either.t) wrapper
   }
 
 let encodeEitherWrapped x =
@@ -67,7 +67,7 @@ let decodeEitherWrapped json =
   | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("decodeEitherWrapped: " ^ message)
 
 type complexWrapped =
-  { cw : ((float, (string) option) Belt.Result.t) wrapper
+  { cw : (((string) option, float) Aeson.Compatibility.Either.t) wrapper
   }
 
 let encodeComplexWrapped x =
@@ -87,7 +87,7 @@ type sumWrapped =
   | SW1
   | SW2 of (int) wrapper
   | SW3 of ((string) option) wrapper
-  | SW4 of ((string, int) Belt.Result.t) wrapper
+  | SW4 of ((int, string) Aeson.Compatibility.Either.t) wrapper
 
 let encodeSumWrapped x =
   match x with
@@ -153,7 +153,7 @@ let decodeTupleWrapped json =
   | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("decodeTupleWrapped: " ^ message)
 
 type 'a0 halfWrapped =
-  { hw : (('a0, int) Belt.Result.t) wrapper
+  { hw : ((int, 'a0) Aeson.Compatibility.Either.t) wrapper
   }
 
 let encodeHalfWrapped encodeA0 x =
@@ -170,7 +170,7 @@ let decodeHalfWrapped decodeA0 json =
   | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("decodeHalfWrapped: " ^ message)
 
 type ('a0, 'a1, 'a2) partiallyWrapped =
-  { pw : (((string * 'a1 * float * 'a2 * 'a0), int) Belt.Result.t) wrapper
+  { pw : ((int, (string * 'a1 * float * 'a2 * 'a0)) Aeson.Compatibility.Either.t) wrapper
   }
 
 let encodePartiallyWrapped encodeA0 encodeA1 encodeA2 x =

--- a/test/interface/golden/product/Wrapper.ml
+++ b/test/interface/golden/product/Wrapper.ml
@@ -12,8 +12,8 @@ let decodeWrapper decodeA0 json =
     { wpa = field "wpa" (fun a -> unwrapResult (decodeA0 a)) json
     }
   with
-  | v -> Js_result.Ok v
-  | exception Aeson.Decode.DecodeError message -> Js_result.Error ("decodeWrapper: " ^ message)
+  | v -> Belt.Result.Ok v
+  | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("decodeWrapper: " ^ message)
 
 type intWrapped =
   { iw : (int) wrapper
@@ -29,8 +29,8 @@ let decodeIntWrapped json =
     { iw = field "iw" (fun a -> unwrapResult (decodeWrapper (wrapResult int) a)) json
     }
   with
-  | v -> Js_result.Ok v
-  | exception Aeson.Decode.DecodeError message -> Js_result.Error ("decodeIntWrapped: " ^ message)
+  | v -> Belt.Result.Ok v
+  | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("decodeIntWrapped: " ^ message)
 
 type maybeWrapped =
   { mw : ((int) option) wrapper
@@ -46,11 +46,11 @@ let decodeMaybeWrapped json =
     { mw = field "mw" (fun a -> unwrapResult (decodeWrapper (wrapResult (optional int)) a)) json
     }
   with
-  | v -> Js_result.Ok v
-  | exception Aeson.Decode.DecodeError message -> Js_result.Error ("decodeMaybeWrapped: " ^ message)
+  | v -> Belt.Result.Ok v
+  | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("decodeMaybeWrapped: " ^ message)
 
 type eitherWrapped =
-  { ew : ((int, float) Aeson.Compatibility.Either.t) wrapper
+  { ew : ((float, int) Belt.Result.t) wrapper
   }
 
 let encodeEitherWrapped x =
@@ -63,11 +63,11 @@ let decodeEitherWrapped json =
     { ew = field "ew" (fun a -> unwrapResult (decodeWrapper (wrapResult (either int Aeson.Decode.float)) a)) json
     }
   with
-  | v -> Js_result.Ok v
-  | exception Aeson.Decode.DecodeError message -> Js_result.Error ("decodeEitherWrapped: " ^ message)
+  | v -> Belt.Result.Ok v
+  | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("decodeEitherWrapped: " ^ message)
 
 type complexWrapped =
-  { cw : (((string) option, float) Aeson.Compatibility.Either.t) wrapper
+  { cw : ((float, (string) option) Belt.Result.t) wrapper
   }
 
 let encodeComplexWrapped x =
@@ -80,14 +80,14 @@ let decodeComplexWrapped json =
     { cw = field "cw" (fun a -> unwrapResult (decodeWrapper (wrapResult (either (optional string) Aeson.Decode.float)) a)) json
     }
   with
-  | v -> Js_result.Ok v
-  | exception Aeson.Decode.DecodeError message -> Js_result.Error ("decodeComplexWrapped: " ^ message)
+  | v -> Belt.Result.Ok v
+  | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("decodeComplexWrapped: " ^ message)
 
 type sumWrapped =
   | SW1
   | SW2 of (int) wrapper
   | SW3 of ((string) option) wrapper
-  | SW4 of ((int, string) Aeson.Compatibility.Either.t) wrapper
+  | SW4 of ((string, int) Belt.Result.t) wrapper
 
 let encodeSumWrapped x =
   match x with
@@ -114,26 +114,26 @@ let encodeSumWrapped x =
 let decodeSumWrapped json =
   match Aeson.Decode.(field "tag" string json) with
   | "SW1" ->
-     Js_result.Ok SW1
+     Belt.Result.Ok SW1
 
   | "SW2" ->
      (match Aeson.Decode.(field "contents" (fun a -> unwrapResult (decodeWrapper (wrapResult int) a)) json) with
-      | v -> Js_result.Ok (SW2 v)
-      | exception Aeson.Decode.DecodeError message -> Js_result.Error ("SW2: " ^ message)
+      | v -> Belt.Result.Ok (SW2 v)
+      | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("SW2: " ^ message)
      )
   | "SW3" ->
      (match Aeson.Decode.(field "contents" (fun a -> unwrapResult (decodeWrapper (wrapResult (optional string)) a)) json) with
-      | v -> Js_result.Ok (SW3 v)
-      | exception Aeson.Decode.DecodeError message -> Js_result.Error ("SW3: " ^ message)
+      | v -> Belt.Result.Ok (SW3 v)
+      | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("SW3: " ^ message)
      )
 
   | "SW4" ->
      (match Aeson.Decode.(field "contents" (fun a -> unwrapResult (decodeWrapper (wrapResult (either int string)) a)) json) with
-      | v -> Js_result.Ok (SW4 v)
-      | exception Aeson.Decode.DecodeError message -> Js_result.Error ("SW4: " ^ message)
+      | v -> Belt.Result.Ok (SW4 v)
+      | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("SW4: " ^ message)
      )
-  | err -> Js_result.Error ("Unknown tag value found '" ^ err ^ "'.")
-  | exception Aeson.Decode.DecodeError message -> Js_result.Error message
+  | err -> Belt.Result.Error ("Unknown tag value found '" ^ err ^ "'.")
+  | exception Aeson.Decode.DecodeError message -> Belt.Result.Error message
 
 type tupleWrapped =
   { tw : ((int * string * float)) wrapper
@@ -149,28 +149,28 @@ let decodeTupleWrapped json =
     { tw = field "tw" (fun a -> unwrapResult (decodeWrapper (wrapResult (tuple3 int string Aeson.Decode.float)) a)) json
     }
   with
-  | v -> Js_result.Ok v
-  | exception Aeson.Decode.DecodeError message -> Js_result.Error ("decodeTupleWrapped: " ^ message)
+  | v -> Belt.Result.Ok v
+  | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("decodeTupleWrapped: " ^ message)
 
 type 'a0 halfWrapped =
-  { hw : ((int, 'a0) Aeson.Compatibility.Either.t) wrapper
+  { hw : ((int, 'a0) Belt.Result.t) wrapper
   }
 
 let encodeHalfWrapped encodeA0 x =
   Aeson.Encode.object_
-    [ ( "hw", (encodeWrapper (Aeson.Encode.either Aeson.Encode.int encodeA0)) x.hw )
+    [ ( "hw", (encodeWrapper (Aeson.Encode.either encodeA0 Aeson.Encode.int)) x.hw )
     ]
 
 let decodeHalfWrapped decodeA0 json =
   match Aeson.Decode.
-    { hw = field "hw" (fun a -> unwrapResult (decodeWrapper (wrapResult (either int (fun a -> unwrapResult (decodeA0 a)))) a)) json
+    { hw = field "hw" (fun a -> unwrapResult (decodeWrapper (wrapResult (either (fun a -> unwrapResult (decodeA0 a)) int)) a)) json
     }
   with
-  | v -> Js_result.Ok v
-  | exception Aeson.Decode.DecodeError message -> Js_result.Error ("decodeHalfWrapped: " ^ message)
+  | v -> Belt.Result.Ok v
+  | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("decodeHalfWrapped: " ^ message)
 
 type ('a0, 'a1, 'a2) partiallyWrapped =
-  { pw : ((int, (string * 'a1 * float * 'a2 * 'a0)) Aeson.Compatibility.Either.t) wrapper
+  { pw : (((string * 'a1 * float * 'a2 * 'a0), int) Belt.Result.t) wrapper
   }
 
 let encodePartiallyWrapped encodeA0 encodeA1 encodeA2 x =
@@ -183,8 +183,8 @@ let decodePartiallyWrapped decodeA0 decodeA1 decodeA2 json =
     { pw = field "pw" (fun a -> unwrapResult (decodeWrapper (wrapResult (either int (tuple5 string (fun a -> unwrapResult (decodeA1 a)) Aeson.Decode.float (fun a -> unwrapResult (decodeA2 a)) (fun a -> unwrapResult (decodeA0 a))))) a)) json
     }
   with
-  | v -> Js_result.Ok v
-  | exception Aeson.Decode.DecodeError message -> Js_result.Error ("decodePartiallyWrapped: " ^ message)
+  | v -> Belt.Result.Ok v
+  | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("decodePartiallyWrapped: " ^ message)
 
 type ('a0, 'a1, 'a2, 'a3, 'a4, 'a5) scrambledTypeParameterRefs =
   { stprb : 'a1
@@ -215,8 +215,8 @@ let decodeScrambledTypeParameterRefs decodeA0 decodeA1 decodeA2 decodeA3 decodeA
     ; stprc = field "stprc" (fun a -> unwrapResult (decodeA2 a)) json
     }
   with
-  | v -> Js_result.Ok v
-  | exception Aeson.Decode.DecodeError message -> Js_result.Error ("decodeScrambledTypeParameterRefs: " ^ message)
+  | v -> Belt.Result.Ok v
+  | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("decodeScrambledTypeParameterRefs: " ^ message)
 
 type wrappedWrapper =
   { ww : (((int) option) wrapper) option
@@ -232,8 +232,8 @@ let decodeWrappedWrapper json =
     { ww = field "ww" (optional (fun a -> unwrapResult (decodeWrapper (wrapResult (optional int)) a))) json
     }
   with
-  | v -> Js_result.Ok v
-  | exception Aeson.Decode.DecodeError message -> Js_result.Error ("decodeWrappedWrapper: " ^ message)
+  | v -> Belt.Result.Ok v
+  | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("decodeWrappedWrapper: " ^ message)
 
 type ('a0, 'a1, 'a2) wrapThree =
   { wp2a : 'a0
@@ -258,8 +258,8 @@ let decodeWrapThree decodeA0 decodeA1 decodeA2 json =
     ; wp2cb = field "wp2cb" (pair (fun a -> unwrapResult (decodeA2 a)) (fun a -> unwrapResult (decodeA1 a))) json
     }
   with
-  | v -> Js_result.Ok v
-  | exception Aeson.Decode.DecodeError message -> Js_result.Error ("decodeWrapThree: " ^ message)
+  | v -> Belt.Result.Ok v
+  | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("decodeWrapThree: " ^ message)
 
 type ('a0, 'a1, 'a2) wrapThreeUnfilled =
   { zed : string
@@ -278,8 +278,8 @@ let decodeWrapThreeUnfilled decodeA0 decodeA1 decodeA2 json =
     ; unfilled = field "unfilled" (fun a -> unwrapResult (decodeWrapThree decodeA0 decodeA1 decodeA2 a)) json
     }
   with
-  | v -> Js_result.Ok v
-  | exception Aeson.Decode.DecodeError message -> Js_result.Error ("decodeWrapThreeUnfilled: " ^ message)
+  | v -> Belt.Result.Ok v
+  | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("decodeWrapThreeUnfilled: " ^ message)
 
 type wrapThreeFilled =
   { foo : string
@@ -298,8 +298,8 @@ let decodeWrapThreeFilled json =
     ; filled = field "filled" (fun a -> unwrapResult (decodeWrapThree (wrapResult int) (wrapResult Aeson.Decode.float) Person.decodePerson a)) json
     }
   with
-  | v -> Js_result.Ok v
-  | exception Aeson.Decode.DecodeError message -> Js_result.Error ("decodeWrapThreeFilled: " ^ message)
+  | v -> Belt.Result.Ok v
+  | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("decodeWrapThreeFilled: " ^ message)
 
 type 'a0 wrapThreePartiallyFilled =
   { bar : string
@@ -321,5 +321,5 @@ let decodeWrapThreePartiallyFilled decodeA0 json =
     ; partiallyFilled = field "partiallyFilled" (fun a -> unwrapResult (decodeWrapThree (wrapResult Aeson.Decode.float) decodeA0 (wrapResult Aeson.Decode.float) a)) json
     }
   with
-  | v -> Js_result.Ok v
-  | exception Aeson.Decode.DecodeError message -> Js_result.Error ("decodeWrapThreePartiallyFilled: " ^ message)
+  | v -> Belt.Result.Ok v
+  | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("decodeWrapThreePartiallyFilled: " ^ message)

--- a/test/interface/golden/product/Wrapper.ml
+++ b/test/interface/golden/product/Wrapper.ml
@@ -153,17 +153,17 @@ let decodeTupleWrapped json =
   | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("decodeTupleWrapped: " ^ message)
 
 type 'a0 halfWrapped =
-  { hw : ((int, 'a0) Belt.Result.t) wrapper
+  { hw : (('a0, int) Belt.Result.t) wrapper
   }
 
 let encodeHalfWrapped encodeA0 x =
   Aeson.Encode.object_
-    [ ( "hw", (encodeWrapper (Aeson.Encode.either encodeA0 Aeson.Encode.int)) x.hw )
+    [ ( "hw", (encodeWrapper (Aeson.Encode.either Aeson.Encode.int encodeA0)) x.hw )
     ]
 
 let decodeHalfWrapped decodeA0 json =
   match Aeson.Decode.
-    { hw = field "hw" (fun a -> unwrapResult (decodeWrapper (wrapResult (either (fun a -> unwrapResult (decodeA0 a)) int)) a)) json
+    { hw = field "hw" (fun a -> unwrapResult (decodeWrapper (wrapResult (either int (fun a -> unwrapResult (decodeA0 a)))) a)) json
     }
   with
   | v -> Belt.Result.Ok v

--- a/test/interface/golden/product/Wrapper.mli
+++ b/test/interface/golden/product/Wrapper.mli
@@ -23,7 +23,7 @@ val encodeMaybeWrapped : maybeWrapped -> Js_json.t
 val decodeMaybeWrapped : Js_json.t -> (maybeWrapped, string) Belt.Result.t
 
 type eitherWrapped =
-  { ew : ((float, int) Belt.Result.t) wrapper
+  { ew : ((int, float) Aeson.Compatibility.Either.t) wrapper
   }
 
 val encodeEitherWrapped : eitherWrapped -> Js_json.t
@@ -31,7 +31,7 @@ val encodeEitherWrapped : eitherWrapped -> Js_json.t
 val decodeEitherWrapped : Js_json.t -> (eitherWrapped, string) Belt.Result.t
 
 type complexWrapped =
-  { cw : ((float, (string) option) Belt.Result.t) wrapper
+  { cw : (((string) option, float) Aeson.Compatibility.Either.t) wrapper
   }
 
 val encodeComplexWrapped : complexWrapped -> Js_json.t
@@ -42,7 +42,7 @@ type sumWrapped =
   | SW1
   | SW2 of (int) wrapper
   | SW3 of ((string) option) wrapper
-  | SW4 of ((string, int) Belt.Result.t) wrapper
+  | SW4 of ((int, string) Aeson.Compatibility.Either.t) wrapper
 
 val encodeSumWrapped : sumWrapped -> Js_json.t
 
@@ -57,7 +57,7 @@ val encodeTupleWrapped : tupleWrapped -> Js_json.t
 val decodeTupleWrapped : Js_json.t -> (tupleWrapped, string) Belt.Result.t
 
 type 'a0 halfWrapped =
-  { hw : (('a0, int) Belt.Result.t) wrapper
+  { hw : ((int, 'a0) Aeson.Compatibility.Either.t) wrapper
   }
 
 val encodeHalfWrapped : ('a0 -> Js_json.t) -> 'a0 halfWrapped -> Js_json.t
@@ -65,7 +65,7 @@ val encodeHalfWrapped : ('a0 -> Js_json.t) -> 'a0 halfWrapped -> Js_json.t
 val decodeHalfWrapped : (Js_json.t -> ('a0, string) Belt.Result.t) -> Js_json.t -> ('a0 halfWrapped, string) Belt.Result.t
 
 type ('a0, 'a1, 'a2) partiallyWrapped =
-  { pw : (((string * 'a1 * float * 'a2 * 'a0), int) Belt.Result.t) wrapper
+  { pw : ((int, (string * 'a1 * float * 'a2 * 'a0)) Aeson.Compatibility.Either.t) wrapper
   }
 
 val encodePartiallyWrapped : ('a0 -> Js_json.t) -> ('a1 -> Js_json.t) -> ('a2 -> Js_json.t) -> ('a0, 'a1, 'a2) partiallyWrapped -> Js_json.t

--- a/test/interface/golden/product/Wrapper.mli
+++ b/test/interface/golden/product/Wrapper.mli
@@ -57,7 +57,7 @@ val encodeTupleWrapped : tupleWrapped -> Js_json.t
 val decodeTupleWrapped : Js_json.t -> (tupleWrapped, string) Belt.Result.t
 
 type 'a0 halfWrapped =
-  { hw : ((int, 'a0) Belt.Result.t) wrapper
+  { hw : (('a0, int) Belt.Result.t) wrapper
   }
 
 val encodeHalfWrapped : ('a0 -> Js_json.t) -> 'a0 halfWrapped -> Js_json.t

--- a/test/interface/golden/product/Wrapper.mli
+++ b/test/interface/golden/product/Wrapper.mli
@@ -4,7 +4,7 @@ type 'a0 wrapper =
 
 val encodeWrapper : ('a0 -> Js_json.t) -> 'a0 wrapper -> Js_json.t
 
-val decodeWrapper : (Js_json.t -> ('a0, string) Js_result.t) -> Js_json.t -> ('a0 wrapper, string) Js_result.t
+val decodeWrapper : (Js_json.t -> ('a0, string) Belt.Result.t) -> Js_json.t -> ('a0 wrapper, string) Belt.Result.t
 
 type intWrapped =
   { iw : (int) wrapper
@@ -12,7 +12,7 @@ type intWrapped =
 
 val encodeIntWrapped : intWrapped -> Js_json.t
 
-val decodeIntWrapped : Js_json.t -> (intWrapped, string) Js_result.t
+val decodeIntWrapped : Js_json.t -> (intWrapped, string) Belt.Result.t
 
 type maybeWrapped =
   { mw : ((int) option) wrapper
@@ -20,33 +20,33 @@ type maybeWrapped =
 
 val encodeMaybeWrapped : maybeWrapped -> Js_json.t
 
-val decodeMaybeWrapped : Js_json.t -> (maybeWrapped, string) Js_result.t
+val decodeMaybeWrapped : Js_json.t -> (maybeWrapped, string) Belt.Result.t
 
 type eitherWrapped =
-  { ew : ((int, float) Aeson.Compatibility.Either.t) wrapper
+  { ew : ((float, int) Belt.Result.t) wrapper
   }
 
 val encodeEitherWrapped : eitherWrapped -> Js_json.t
 
-val decodeEitherWrapped : Js_json.t -> (eitherWrapped, string) Js_result.t
+val decodeEitherWrapped : Js_json.t -> (eitherWrapped, string) Belt.Result.t
 
 type complexWrapped =
-  { cw : (((string) option, float) Aeson.Compatibility.Either.t) wrapper
+  { cw : ((float, (string) option) Belt.Result.t) wrapper
   }
 
 val encodeComplexWrapped : complexWrapped -> Js_json.t
 
-val decodeComplexWrapped : Js_json.t -> (complexWrapped, string) Js_result.t
+val decodeComplexWrapped : Js_json.t -> (complexWrapped, string) Belt.Result.t
 
 type sumWrapped =
   | SW1
   | SW2 of (int) wrapper
   | SW3 of ((string) option) wrapper
-  | SW4 of ((int, string) Aeson.Compatibility.Either.t) wrapper
+  | SW4 of ((string, int) Belt.Result.t) wrapper
 
 val encodeSumWrapped : sumWrapped -> Js_json.t
 
-val decodeSumWrapped : Js_json.t -> (sumWrapped, string) Js_result.t
+val decodeSumWrapped : Js_json.t -> (sumWrapped, string) Belt.Result.t
 
 type tupleWrapped =
   { tw : ((int * string * float)) wrapper
@@ -54,23 +54,23 @@ type tupleWrapped =
 
 val encodeTupleWrapped : tupleWrapped -> Js_json.t
 
-val decodeTupleWrapped : Js_json.t -> (tupleWrapped, string) Js_result.t
+val decodeTupleWrapped : Js_json.t -> (tupleWrapped, string) Belt.Result.t
 
 type 'a0 halfWrapped =
-  { hw : ((int, 'a0) Aeson.Compatibility.Either.t) wrapper
+  { hw : ((int, 'a0) Belt.Result.t) wrapper
   }
 
 val encodeHalfWrapped : ('a0 -> Js_json.t) -> 'a0 halfWrapped -> Js_json.t
 
-val decodeHalfWrapped : (Js_json.t -> ('a0, string) Js_result.t) -> Js_json.t -> ('a0 halfWrapped, string) Js_result.t
+val decodeHalfWrapped : (Js_json.t -> ('a0, string) Belt.Result.t) -> Js_json.t -> ('a0 halfWrapped, string) Belt.Result.t
 
 type ('a0, 'a1, 'a2) partiallyWrapped =
-  { pw : ((int, (string * 'a1 * float * 'a2 * 'a0)) Aeson.Compatibility.Either.t) wrapper
+  { pw : (((string * 'a1 * float * 'a2 * 'a0), int) Belt.Result.t) wrapper
   }
 
 val encodePartiallyWrapped : ('a0 -> Js_json.t) -> ('a1 -> Js_json.t) -> ('a2 -> Js_json.t) -> ('a0, 'a1, 'a2) partiallyWrapped -> Js_json.t
 
-val decodePartiallyWrapped : (Js_json.t -> ('a0, string) Js_result.t) -> (Js_json.t -> ('a1, string) Js_result.t) -> (Js_json.t -> ('a2, string) Js_result.t) -> Js_json.t -> (('a0, 'a1, 'a2) partiallyWrapped, string) Js_result.t
+val decodePartiallyWrapped : (Js_json.t -> ('a0, string) Belt.Result.t) -> (Js_json.t -> ('a1, string) Belt.Result.t) -> (Js_json.t -> ('a2, string) Belt.Result.t) -> Js_json.t -> (('a0, 'a1, 'a2) partiallyWrapped, string) Belt.Result.t
 
 type ('a0, 'a1, 'a2, 'a3, 'a4, 'a5) scrambledTypeParameterRefs =
   { stprb : 'a1
@@ -83,7 +83,7 @@ type ('a0, 'a1, 'a2, 'a3, 'a4, 'a5) scrambledTypeParameterRefs =
 
 val encodeScrambledTypeParameterRefs : ('a0 -> Js_json.t) -> ('a1 -> Js_json.t) -> ('a2 -> Js_json.t) -> ('a3 -> Js_json.t) -> ('a4 -> Js_json.t) -> ('a5 -> Js_json.t) -> ('a0, 'a1, 'a2, 'a3, 'a4, 'a5) scrambledTypeParameterRefs -> Js_json.t
 
-val decodeScrambledTypeParameterRefs : (Js_json.t -> ('a0, string) Js_result.t) -> (Js_json.t -> ('a1, string) Js_result.t) -> (Js_json.t -> ('a2, string) Js_result.t) -> (Js_json.t -> ('a3, string) Js_result.t) -> (Js_json.t -> ('a4, string) Js_result.t) -> (Js_json.t -> ('a5, string) Js_result.t) -> Js_json.t -> (('a0, 'a1, 'a2, 'a3, 'a4, 'a5) scrambledTypeParameterRefs, string) Js_result.t
+val decodeScrambledTypeParameterRefs : (Js_json.t -> ('a0, string) Belt.Result.t) -> (Js_json.t -> ('a1, string) Belt.Result.t) -> (Js_json.t -> ('a2, string) Belt.Result.t) -> (Js_json.t -> ('a3, string) Belt.Result.t) -> (Js_json.t -> ('a4, string) Belt.Result.t) -> (Js_json.t -> ('a5, string) Belt.Result.t) -> Js_json.t -> (('a0, 'a1, 'a2, 'a3, 'a4, 'a5) scrambledTypeParameterRefs, string) Belt.Result.t
 
 type wrappedWrapper =
   { ww : (((int) option) wrapper) option
@@ -91,7 +91,7 @@ type wrappedWrapper =
 
 val encodeWrappedWrapper : wrappedWrapper -> Js_json.t
 
-val decodeWrappedWrapper : Js_json.t -> (wrappedWrapper, string) Js_result.t
+val decodeWrappedWrapper : Js_json.t -> (wrappedWrapper, string) Belt.Result.t
 
 type ('a0, 'a1, 'a2) wrapThree =
   { wp2a : 'a0
@@ -102,7 +102,7 @@ type ('a0, 'a1, 'a2) wrapThree =
 
 val encodeWrapThree : ('a0 -> Js_json.t) -> ('a1 -> Js_json.t) -> ('a2 -> Js_json.t) -> ('a0, 'a1, 'a2) wrapThree -> Js_json.t
 
-val decodeWrapThree : (Js_json.t -> ('a0, string) Js_result.t) -> (Js_json.t -> ('a1, string) Js_result.t) -> (Js_json.t -> ('a2, string) Js_result.t) -> Js_json.t -> (('a0, 'a1, 'a2) wrapThree, string) Js_result.t
+val decodeWrapThree : (Js_json.t -> ('a0, string) Belt.Result.t) -> (Js_json.t -> ('a1, string) Belt.Result.t) -> (Js_json.t -> ('a2, string) Belt.Result.t) -> Js_json.t -> (('a0, 'a1, 'a2) wrapThree, string) Belt.Result.t
 
 type ('a0, 'a1, 'a2) wrapThreeUnfilled =
   { zed : string
@@ -111,7 +111,7 @@ type ('a0, 'a1, 'a2) wrapThreeUnfilled =
 
 val encodeWrapThreeUnfilled : ('a0 -> Js_json.t) -> ('a1 -> Js_json.t) -> ('a2 -> Js_json.t) -> ('a0, 'a1, 'a2) wrapThreeUnfilled -> Js_json.t
 
-val decodeWrapThreeUnfilled : (Js_json.t -> ('a0, string) Js_result.t) -> (Js_json.t -> ('a1, string) Js_result.t) -> (Js_json.t -> ('a2, string) Js_result.t) -> Js_json.t -> (('a0, 'a1, 'a2) wrapThreeUnfilled, string) Js_result.t
+val decodeWrapThreeUnfilled : (Js_json.t -> ('a0, string) Belt.Result.t) -> (Js_json.t -> ('a1, string) Belt.Result.t) -> (Js_json.t -> ('a2, string) Belt.Result.t) -> Js_json.t -> (('a0, 'a1, 'a2) wrapThreeUnfilled, string) Belt.Result.t
 
 type wrapThreeFilled =
   { foo : string
@@ -120,7 +120,7 @@ type wrapThreeFilled =
 
 val encodeWrapThreeFilled : wrapThreeFilled -> Js_json.t
 
-val decodeWrapThreeFilled : Js_json.t -> (wrapThreeFilled, string) Js_result.t
+val decodeWrapThreeFilled : Js_json.t -> (wrapThreeFilled, string) Belt.Result.t
 
 type 'a0 wrapThreePartiallyFilled =
   { bar : string
@@ -130,4 +130,4 @@ type 'a0 wrapThreePartiallyFilled =
 
 val encodeWrapThreePartiallyFilled : ('a0 -> Js_json.t) -> 'a0 wrapThreePartiallyFilled -> Js_json.t
 
-val decodeWrapThreePartiallyFilled : (Js_json.t -> ('a0, string) Js_result.t) -> Js_json.t -> ('a0 wrapThreePartiallyFilled, string) Js_result.t
+val decodeWrapThreePartiallyFilled : (Js_json.t -> ('a0, string) Belt.Result.t) -> Js_json.t -> ('a0 wrapThreePartiallyFilled, string) Belt.Result.t

--- a/test/interface/golden/sum/NameOrIdNumber.ml
+++ b/test/interface/golden/sum/NameOrIdNumber.ml
@@ -19,13 +19,13 @@ let decodeNameOrIdNumber json =
   match Aeson.Decode.(field "tag" string json) with
   | "Name" ->
      (match Aeson.Decode.(field "contents" string json) with
-      | v -> Js_result.Ok (Name v)
-      | exception Aeson.Decode.DecodeError message -> Js_result.Error ("Name: " ^ message)
+      | v -> Belt.Result.Ok (Name v)
+      | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("Name: " ^ message)
      )
   | "IdNumber" ->
      (match Aeson.Decode.(field "contents" int json) with
-      | v -> Js_result.Ok (IdNumber v)
-      | exception Aeson.Decode.DecodeError message -> Js_result.Error ("IdNumber: " ^ message)
+      | v -> Belt.Result.Ok (IdNumber v)
+      | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("IdNumber: " ^ message)
      )
-  | err -> Js_result.Error ("Unknown tag value found '" ^ err ^ "'.")
-  | exception Aeson.Decode.DecodeError message -> Js_result.Error message
+  | err -> Belt.Result.Error ("Unknown tag value found '" ^ err ^ "'.")
+  | exception Aeson.Decode.DecodeError message -> Belt.Result.Error message

--- a/test/interface/golden/sum/NameOrIdNumber.mli
+++ b/test/interface/golden/sum/NameOrIdNumber.mli
@@ -4,4 +4,4 @@ type nameOrIdNumber =
 
 val encodeNameOrIdNumber : nameOrIdNumber -> Js_json.t
 
-val decodeNameOrIdNumber : Js_json.t -> (nameOrIdNumber, string) Js_result.t
+val decodeNameOrIdNumber : Js_json.t -> (nameOrIdNumber, string) Belt.Result.t

--- a/test/interface/golden/sum/NewType.ml
+++ b/test/interface/golden/sum/NewType.ml
@@ -8,5 +8,5 @@ let encodeNewType x =
 
 let decodeNewType json =
   match Aeson.Decode.int json with
-  | v -> Js_result.Ok (NewType v)
-  | exception Aeson.Decode.DecodeError msg -> Js_result.Error ("decodeNewType: " ^ msg)
+  | v -> Belt.Result.Ok (NewType v)
+  | exception Aeson.Decode.DecodeError msg -> Belt.Result.Error ("decodeNewType: " ^ msg)

--- a/test/interface/golden/sum/NewType.mli
+++ b/test/interface/golden/sum/NewType.mli
@@ -3,4 +3,4 @@ type newType =
 
 val encodeNewType : newType -> Js_json.t
 
-val decodeNewType : Js_json.t -> (newType, string) Js_result.t
+val decodeNewType : Js_json.t -> (newType, string) Belt.Result.t

--- a/test/interface/golden/sum/OnOrOff.ml
+++ b/test/interface/golden/sum/OnOrOff.ml
@@ -11,7 +11,7 @@ let encodeOnOrOff x =
 
 let decodeOnOrOff json =
   match Js_json.decodeString json with
-  | Some "On" -> Js_result.Ok On
-  | Some "Off" -> Js_result.Ok Off
-  | Some err -> Js_result.Error ("decodeOnOrOff: unknown enumeration '" ^ err ^ "'.")
-  | None -> Js_result.Error "decodeOnOrOff: expected a top-level JSON string."
+  | Some "On" -> Belt.Result.Ok On
+  | Some "Off" -> Belt.Result.Ok Off
+  | Some err -> Belt.Result.Error ("decodeOnOrOff: unknown enumeration '" ^ err ^ "'.")
+  | None -> Belt.Result.Error "decodeOnOrOff: expected a top-level JSON string."

--- a/test/interface/golden/sum/OnOrOff.mli
+++ b/test/interface/golden/sum/OnOrOff.mli
@@ -4,4 +4,4 @@ type onOrOff =
 
 val encodeOnOrOff : onOrOff -> Js_json.t
 
-val decodeOnOrOff : Js_json.t -> (onOrOff, string) Js_result.t
+val decodeOnOrOff : Js_json.t -> (onOrOff, string) Belt.Result.t

--- a/test/interface/golden/sum/Result.ml
+++ b/test/interface/golden/sum/Result.ml
@@ -19,13 +19,13 @@ let decodeResult decodeA0 decodeA1 json =
   match Aeson.Decode.(field "tag" string json) with
   | "Success" ->
      (match Aeson.Decode.(field "contents" (fun a -> unwrapResult (decodeA0 a)) json) with
-      | v -> Js_result.Ok (Success v)
-      | exception Aeson.Decode.DecodeError message -> Js_result.Error ("Success: " ^ message)
+      | v -> Belt.Result.Ok (Success v)
+      | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("Success: " ^ message)
      )
   | "Error" ->
      (match Aeson.Decode.(field "contents" (fun a -> unwrapResult (decodeA1 a)) json) with
-      | v -> Js_result.Ok (Error v)
-      | exception Aeson.Decode.DecodeError message -> Js_result.Error ("Error: " ^ message)
+      | v -> Belt.Result.Ok (Error v)
+      | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("Error: " ^ message)
      )
-  | err -> Js_result.Error ("Unknown tag value found '" ^ err ^ "'.")
-  | exception Aeson.Decode.DecodeError message -> Js_result.Error message
+  | err -> Belt.Result.Error ("Unknown tag value found '" ^ err ^ "'.")
+  | exception Aeson.Decode.DecodeError message -> Belt.Result.Error message

--- a/test/interface/golden/sum/Result.mli
+++ b/test/interface/golden/sum/Result.mli
@@ -4,4 +4,4 @@ type ('a0, 'a1) result =
 
 val encodeResult : ('a0 -> Js_json.t) -> ('a1 -> Js_json.t) -> ('a0, 'a1) result -> Js_json.t
 
-val decodeResult : (Js_json.t -> ('a0, string) Js_result.t) -> (Js_json.t -> ('a1, string) Js_result.t) -> Js_json.t -> (('a0, 'a1) result, string) Js_result.t
+val decodeResult : (Js_json.t -> ('a0, string) Belt.Result.t) -> (Js_json.t -> ('a1, string) Belt.Result.t) -> Js_json.t -> (('a0, 'a1) result, string) Belt.Result.t

--- a/test/interface/golden/sum/SumVariant.ml
+++ b/test/interface/golden/sum/SumVariant.ml
@@ -41,18 +41,18 @@ let encodeSumVariant x =
 let decodeSumVariant json =
   match Aeson.Decode.(field "tag" string json) with
   | "HasNothing" ->
-     Js_result.Ok HasNothing
+     Belt.Result.Ok HasNothing
 
   | "HasSingleInt" ->
      (match Aeson.Decode.(field "contents" int json) with
-      | v -> Js_result.Ok (HasSingleInt v)
-      | exception Aeson.Decode.DecodeError message -> Js_result.Error ("HasSingleInt: " ^ message)
+      | v -> Belt.Result.Ok (HasSingleInt v)
+      | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("HasSingleInt: " ^ message)
      )
 
   | "HasSingleTuple" ->
      (match Aeson.Decode.(field "contents" (pair int int) json) with
-      | v -> Js_result.Ok (HasSingleTuple v)
-      | exception Aeson.Decode.DecodeError message -> Js_result.Error ("HasSingleTuple: " ^ message)
+      | v -> Belt.Result.Ok (HasSingleTuple v)
+      | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("HasSingleTuple: " ^ message)
      )
   | "HasMultipleInts" ->
      (match Aeson.Decode.(field "contents" Js.Json.decodeArray json) with
@@ -61,12 +61,12 @@ let decodeSumVariant json =
           | v0 ->
              (match Aeson.Decode.int v.(1) with
               | v1 ->
-                 Js_result.Ok (HasMultipleInts (v0, v1))
-              | exception Aeson.Decode.DecodeError message -> Js_result.Error ("HasMultipleInts: " ^ message)
+                 Belt.Result.Ok (HasMultipleInts (v0, v1))
+              | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("HasMultipleInts: " ^ message)
              )
-          | exception Aeson.Decode.DecodeError message -> Js_result.Error ("HasMultipleInts: " ^ message)
+          | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("HasMultipleInts: " ^ message)
          )
-      | None -> Js_result.Error ("HasMultipleInts expected an array.")
+      | None -> Belt.Result.Error ("HasMultipleInts expected an array.")
      )
 
   | "HasMultipleTuples" ->
@@ -76,12 +76,12 @@ let decodeSumVariant json =
           | v0 ->
              (match Aeson.Decode.(pair int int) v.(1) with
               | v1 ->
-                 Js_result.Ok (HasMultipleTuples (v0, v1))
-              | exception Aeson.Decode.DecodeError message -> Js_result.Error ("HasMultipleTuples: " ^ message)
+                 Belt.Result.Ok (HasMultipleTuples (v0, v1))
+              | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("HasMultipleTuples: " ^ message)
              )
-          | exception Aeson.Decode.DecodeError message -> Js_result.Error ("HasMultipleTuples: " ^ message)
+          | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("HasMultipleTuples: " ^ message)
          )
-      | None -> Js_result.Error ("HasMultipleTuples expected an array.")
+      | None -> Belt.Result.Error ("HasMultipleTuples expected an array.")
      )
 
   | "HasMixed" ->
@@ -93,14 +93,14 @@ let decodeSumVariant json =
               | v1 ->
                  (match Aeson.Decode.float v.(2) with
                   | v2 ->
-                     Js_result.Ok (HasMixed (v0, v1, v2))
-                  | exception Aeson.Decode.DecodeError message -> Js_result.Error ("HasMixed: " ^ message)
+                     Belt.Result.Ok (HasMixed (v0, v1, v2))
+                  | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("HasMixed: " ^ message)
                  )
-              | exception Aeson.Decode.DecodeError message -> Js_result.Error ("HasMixed: " ^ message)
+              | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("HasMixed: " ^ message)
              )
-          | exception Aeson.Decode.DecodeError message -> Js_result.Error ("HasMixed: " ^ message)
+          | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("HasMixed: " ^ message)
          )
-      | None -> Js_result.Error ("HasMixed expected an array.")
+      | None -> Belt.Result.Error ("HasMixed expected an array.")
      )
-  | err -> Js_result.Error ("Unknown tag value found '" ^ err ^ "'.")
-  | exception Aeson.Decode.DecodeError message -> Js_result.Error message
+  | err -> Belt.Result.Error ("Unknown tag value found '" ^ err ^ "'.")
+  | exception Aeson.Decode.DecodeError message -> Belt.Result.Error message

--- a/test/interface/golden/sum/SumVariant.mli
+++ b/test/interface/golden/sum/SumVariant.mli
@@ -8,4 +8,4 @@ type sumVariant =
 
 val encodeSumVariant : sumVariant -> Js_json.t
 
-val decodeSumVariant : Js_json.t -> (sumVariant, string) Js_result.t
+val decodeSumVariant : Js_json.t -> (sumVariant, string) Belt.Result.t

--- a/test/interface/golden/sum/SumWithRecord.ml
+++ b/test/interface/golden/sum/SumWithRecord.ml
@@ -46,8 +46,8 @@ let decodeSumWithRecordA1 json =
     { a1 = field "a1" int json
     }
   with
-  | v -> Js_result.Ok v
-  | exception Aeson.Decode.DecodeError message -> Js_result.Error ("decodeSumWithRecordA1: " ^ message)
+  | v -> Belt.Result.Ok v
+  | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("decodeSumWithRecordA1: " ^ message)
 
 let decodeSumWithRecordB2 json =
   match Aeson.Decode.
@@ -55,20 +55,20 @@ let decodeSumWithRecordB2 json =
     ; b3 = field "b3" int json
     }
   with
-  | v -> Js_result.Ok v
-  | exception Aeson.Decode.DecodeError message -> Js_result.Error ("decodeSumWithRecordB2: " ^ message)
+  | v -> Belt.Result.Ok v
+  | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("decodeSumWithRecordB2: " ^ message)
 
 let decodeSumWithRecord json =
   match Aeson.Decode.(field "tag" string json) with
   | "A1" ->
      (match decodeSumWithRecordA1 json with
-      | Js_result.Ok v -> Js_result.Ok (A1 v)
-      | Js_result.Error message -> Js_result.Error ("decodeSumWithRecord: " ^ message)
+      | Belt.Result.Ok v -> Belt.Result.Ok (A1 v)
+      | Belt.Result.Error message -> Belt.Result.Error ("decodeSumWithRecord: " ^ message)
      )
   | "B2" ->
      (match decodeSumWithRecordB2 json with
-      | Js_result.Ok v -> Js_result.Ok (B2 v)
-      | Js_result.Error message -> Js_result.Error ("decodeSumWithRecord: " ^ message)
+      | Belt.Result.Ok v -> Belt.Result.Ok (B2 v)
+      | Belt.Result.Error message -> Belt.Result.Error ("decodeSumWithRecord: " ^ message)
      )
-  | err -> Js_result.Error ("Unknown tag value found '" ^ err ^ "'.")
-  | exception Aeson.Decode.DecodeError message -> Js_result.Error message
+  | err -> Belt.Result.Error ("Unknown tag value found '" ^ err ^ "'.")
+  | exception Aeson.Decode.DecodeError message -> Belt.Result.Error message

--- a/test/interface/golden/sum/SumWithRecord.mli
+++ b/test/interface/golden/sum/SumWithRecord.mli
@@ -17,8 +17,8 @@ val encodeSumWithRecordB2 : sumWithRecordB2 -> Js_json.t
 
 val encodeSumWithRecord : sumWithRecord -> Js_json.t
 
-val decodeSumWithRecordA1 : Js_json.t -> (sumWithRecordA1, string) Js_result.t
+val decodeSumWithRecordA1 : Js_json.t -> (sumWithRecordA1, string) Belt.Result.t
 
-val decodeSumWithRecordB2 : Js_json.t -> (sumWithRecordB2, string) Js_result.t
+val decodeSumWithRecordB2 : Js_json.t -> (sumWithRecordB2, string) Belt.Result.t
 
-val decodeSumWithRecord : Js_json.t -> (sumWithRecord, string) Js_result.t
+val decodeSumWithRecord : Js_json.t -> (sumWithRecord, string) Belt.Result.t

--- a/test/interface/golden/sum/WithTuple.ml
+++ b/test/interface/golden/sum/WithTuple.ml
@@ -8,5 +8,5 @@ let encodeWithTuple x =
 
 let decodeWithTuple json =
   match Aeson.Decode.(pair int int) json with
-  | v -> Js_result.Ok (WithTuple v)
-  | exception Aeson.Decode.DecodeError msg -> Js_result.Error ("decodeWithTuple: " ^ msg)
+  | v -> Belt.Result.Ok (WithTuple v)
+  | exception Aeson.Decode.DecodeError msg -> Belt.Result.Error ("decodeWithTuple: " ^ msg)

--- a/test/interface/golden/sum/WithTuple.mli
+++ b/test/interface/golden/sum/WithTuple.mli
@@ -3,4 +3,4 @@ type withTuple =
 
 val encodeWithTuple : withTuple -> Js_json.t
 
-val decodeWithTuple : Js_json.t -> (withTuple, string) Js_result.t
+val decodeWithTuple : Js_json.t -> (withTuple, string) Belt.Result.t

--- a/test/interface/golden/yarn.lock
+++ b/test/interface/golden/yarn.lock
@@ -3,14 +3,14 @@
 
 
 "@babel/code-frame@^7.0.0-beta.35":
-  version "7.0.0-beta.46"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.46.tgz#e0d002100805daab1461c0fcb32a07e304f3a4f4"
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.49.tgz#becd805482734440c9d137e46d77340e64d7f51b"
   dependencies:
-    "@babel/highlight" "7.0.0-beta.46"
+    "@babel/highlight" "7.0.0-beta.49"
 
-"@babel/highlight@7.0.0-beta.46":
-  version "7.0.0-beta.46"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0-beta.46.tgz#c553c51e65f572bdedd6eff66fc0bb563016645e"
+"@babel/highlight@7.0.0-beta.49":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0-beta.49.tgz#96bdc6b43e13482012ba6691b1018492d39622cc"
   dependencies:
     chalk "^2.0.0"
     esutils "^2.0.2"
@@ -37,8 +37,8 @@ acorn-globals@^4.1.0:
     acorn "^5.0.0"
 
 acorn@^5.0.0, acorn@^5.3.0:
-  version "5.5.3"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.5.3.tgz#f473dd47e0277a08e28e9bec5aeeb04751f0b8c9"
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.6.1.tgz#c9e50c3e3717cf897f1b071ceadbb543bbc0a8d4"
 
 ajv@^5.1.0:
   version "5.5.2"
@@ -101,8 +101,8 @@ aproba@^1.0.3:
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
 
 are-we-there-yet@~1.1.2:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz#bb5dca382bb94f05e15194373d16fd3ba1ca110d"
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz#4b35c2944f062a8bfcda66410760350fe9ddfc21"
   dependencies:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
@@ -172,16 +172,16 @@ async@^1.4.0:
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
 async@^2.1.4:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.6.0.tgz#61a29abb6fcc026fea77e56d1c6ec53a795951f4"
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.1.tgz#b245a23ca71930044ec53fa46aa00a3e87c6a610"
   dependencies:
-    lodash "^4.14.0"
+    lodash "^4.17.10"
 
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
 
-atob@^2.0.0:
+atob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.1.tgz#ae2d5a729477f289d60dd7f96a6314a22dd6c22a"
 
@@ -245,12 +245,12 @@ babel-helpers@^6.24.1:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-jest@^22.4.3:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-22.4.3.tgz#4b7a0b6041691bbd422ab49b3b73654a49a6627a"
+babel-jest@^22.4.4:
+  version "22.4.4"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-22.4.4.tgz#977259240420e227444ebe49e226a61e49ea659d"
   dependencies:
     babel-plugin-istanbul "^4.1.5"
-    babel-preset-jest "^22.4.3"
+    babel-preset-jest "^22.4.4"
 
 babel-messages@^6.23.0:
   version "6.23.0"
@@ -267,19 +267,19 @@ babel-plugin-istanbul@^4.1.5:
     istanbul-lib-instrument "^1.10.1"
     test-exclude "^4.2.1"
 
-babel-plugin-jest-hoist@^22.4.3:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.3.tgz#7d8bcccadc2667f96a0dcc6afe1891875ee6c14a"
+babel-plugin-jest-hoist@^22.4.4:
+  version "22.4.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.4.tgz#b9851906eab34c7bf6f8c895a2b08bea1a844c0b"
 
 babel-plugin-syntax-object-rest-spread@^6.13.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
 
-babel-preset-jest@^22.4.3:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-22.4.3.tgz#e92eef9813b7026ab4ca675799f37419b5a44156"
+babel-preset-jest@^22.4.4:
+  version "22.4.4"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-22.4.4.tgz#ec9fbd8bcd7dfd24b8b5320e0e688013235b7c39"
   dependencies:
-    babel-plugin-jest-hoist "^22.4.3"
+    babel-plugin-jest-hoist "^22.4.4"
     babel-plugin-syntax-object-rest-spread "^6.13.0"
 
 babel-register@^6.26.0:
@@ -360,18 +360,6 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-boom@4.x.x:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/boom/-/boom-4.3.1.tgz#4f8a3005cb4a7e3889f749030fd25b96e01d2e31"
-  dependencies:
-    hoek "4.x.x"
-
-boom@5.x.x:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/boom/-/boom-5.2.0.tgz#5dd9da6ee3a5f302077436290cb717d3f4a54e02"
-  dependencies:
-    hoek "4.x.x"
-
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -424,9 +412,9 @@ bs-aeson@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/bs-aeson/-/bs-aeson-2.0.0.tgz#ec6d2198cbbd626c9ecf0a1fdc03ce10c96bdbfc"
 
-"bs-aeson@github:plow-technologies/bs-aeson#8eed965c4841c5788ebf40a22c7df3aafcaa5749":
+bs-aeson@^3.0.0:
   version "3.0.0"
-  resolved "https://codeload.github.com/plow-technologies/bs-aeson/tar.gz/8eed965c4841c5788ebf40a22c7df3aafcaa5749"
+  resolved "https://registry.yarnpkg.com/bs-aeson/-/bs-aeson-3.0.0.tgz#7478a3797e43b583fcdc1fe9f6cd7264e27faa49"
 
 bs-node-fetch@^0.1.2:
   version "0.1.2"
@@ -438,9 +426,9 @@ bs-node-fetch@^0.1.2:
   version "0.0.1"
   resolved "https://codeload.github.com/buckletypes/bs-node/tar.gz/20ef6d2d7c00e923aba33b0629ca5623a4460712"
 
-bs-platform@^3.1.3:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-3.1.4.tgz#fe8495443b35aff73dfb61cba1e6d7b88311910b"
+bs-platform@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-3.1.5.tgz#fb34ee4702bc9163848d5537096c4f31ebaeed40"
 
 bser@^2.0.0:
   version "2.0.0"
@@ -449,8 +437,8 @@ bser@^2.0.0:
     node-int64 "^0.4.0"
 
 buffer-from@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.0.0.tgz#4cb8832d23612589b0406e9e2956c17f06fdf531"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.0.tgz#87fcaa3a298358e0ade6e442cfce840740d1ad04"
 
 builtin-modules@^1.0.0:
   version "1.1.1"
@@ -481,6 +469,12 @@ camelcase@^1.0.2:
 camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
+
+capture-exit@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/capture-exit/-/capture-exit-1.2.0.tgz#1c5fcc489fd0ab00d4f1ac7ae1072e3173fbab6f"
+  dependencies:
+    rsvp "^3.3.3"
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -576,8 +570,8 @@ combined-stream@1.0.6, combined-stream@~1.0.5:
     delayed-stream "~1.0.0"
 
 compare-versions@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.1.0.tgz#43310256a5c555aaed4193c04d8f154cf9c6efd5"
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.2.1.tgz#a49eb7689d4caaf0b6db5220173fd279614000f7"
 
 component-emitter@^1.2.1:
   version "1.2.1"
@@ -600,8 +594,8 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
 
 core-js@^2.4.0, core-js@^2.5.0:
-  version "2.5.5"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.5.tgz#b14dde936c640c0579a6b50cabcc132dd6127e3b"
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -615,19 +609,13 @@ cross-spawn@^5.0.1:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cryptiles@3.x.x:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-3.1.2.tgz#a89fbb220f5ce25ec56e8c4aa8a4fd7b5b0d29fe"
-  dependencies:
-    boom "5.x.x"
-
 cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.2.tgz#b8036170c79f07a90ff2f16e22284027a243848b"
 
-"cssstyle@>= 0.2.37 < 0.3.0":
-  version "0.2.37"
-  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-0.2.37.tgz#541097234cb2513c83ceed3acddc27ff27987d54"
+"cssstyle@>= 0.3.1 < 0.4.0":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-0.3.1.tgz#6da9b4cff1bc5d716e6e5fe8e04fcb1b50a49adf"
   dependencies:
     cssom "0.3.x"
 
@@ -665,9 +653,9 @@ decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
 
-deep-extend@^0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.5.1.tgz#b894a9dd90d3023fbf1c55a394fb858eb2066f1f"
+deep-extend@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
 
 deep-is@~0.1.3:
   version "0.1.3"
@@ -756,8 +744,8 @@ error-ex@^1.2.0:
     is-arrayish "^0.2.1"
 
 es-abstract@^1.5.1:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.11.0.tgz#cce87d518f0496893b1a30cd8461835535480681"
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.12.0.tgz#9dbbdd27c6856f0001421ca18782d786bf8a6165"
   dependencies:
     es-to-primitive "^1.1.1"
     function-bind "^1.1.1"
@@ -850,7 +838,7 @@ expand-range@^1.8.1:
   dependencies:
     fill-range "^2.1.0"
 
-expect@^22.4.3:
+expect@^22.4.0:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/expect/-/expect-22.4.3.tgz#d5a29d0a0e1fb2153557caef2674d4547e914674"
   dependencies:
@@ -935,12 +923,12 @@ fileset@^2.0.2:
     minimatch "^3.0.3"
 
 fill-range@^2.1.0:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-2.2.3.tgz#50b77dfd7e469bc7492470963699fe7a8485a723"
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-2.2.4.tgz#eb1e773abb056dcd8df2bfdf6af59b8b3a936565"
   dependencies:
     is-number "^2.1.0"
     isobject "^2.0.0"
-    randomatic "^1.1.3"
+    randomatic "^3.0.0"
     repeat-element "^1.1.2"
     repeat-string "^1.5.2"
 
@@ -1008,14 +996,14 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
 
-fsevents@^1.1.1:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.3.tgz#08292982e7059f6674c93d8b829c1e8604979ac0"
+fsevents@^1.2.3:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.4.tgz#f41dcb1af2582af3692da36fc55cbd8e1041c426"
   dependencies:
     nan "^2.9.2"
-    node-pre-gyp "^0.9.0"
+    node-pre-gyp "^0.10.0"
 
-function-bind@^1.0.2, function-bind@^1.1.1:
+function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
 
@@ -1153,23 +1141,10 @@ has-values@^1.0.0:
     kind-of "^4.0.0"
 
 has@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/has/-/has-1.0.1.tgz#8461733f538b0837c9361e39a9ab9e9704dc2f28"
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
   dependencies:
-    function-bind "^1.0.2"
-
-hawk@~6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/hawk/-/hawk-6.0.2.tgz#af4d914eb065f9b5ce4d9d11c1cb2126eecc3038"
-  dependencies:
-    boom "4.x.x"
-    cryptiles "3.x.x"
-    hoek "4.x.x"
-    sntp "2.x.x"
-
-hoek@4.x.x:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
+    function-bind "^1.1.1"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -1201,10 +1176,10 @@ iconv-lite@0.4.19:
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
 iconv-lite@^0.4.4, iconv-lite@~0.4.13:
-  version "0.4.21"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.21.tgz#c47f8733d02171189ebc4a400f3218d348094798"
+  version "0.4.23"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
   dependencies:
-    safer-buffer "^2.1.0"
+    safer-buffer ">= 2.1.2 < 3"
 
 ignore-walk@^3.0.1:
   version "3.0.1"
@@ -1509,8 +1484,8 @@ istanbul-lib-source-maps@^1.2.1:
     source-map "^0.5.3"
 
 istanbul-lib-source-maps@^1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.4.tgz#cc7ccad61629f4efff8e2f78adb8c522c9976ec7"
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.5.tgz#ffe6be4e7ab86d3603e4290d54990b14506fc9b1"
   dependencies:
     debug "^3.1.0"
     istanbul-lib-coverage "^1.2.0"
@@ -1524,15 +1499,15 @@ istanbul-reports@^1.3.0:
   dependencies:
     handlebars "^4.0.3"
 
-jest-changed-files@^22.4.3:
+jest-changed-files@^22.2.0:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-22.4.3.tgz#8882181e022c38bd46a2e4d18d44d19d90a90fb2"
   dependencies:
     throat "^4.0.0"
 
-jest-cli@^22.4.3:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-22.4.3.tgz#bf16c4a5fb7edc3fa5b9bb7819e34139e88a72c7"
+jest-cli@^22.4.4:
+  version "22.4.4"
+  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-22.4.4.tgz#68cd2a2aae983adb1e6638248ca21082fd6d9e90"
   dependencies:
     ansi-escapes "^3.0.0"
     chalk "^2.0.1"
@@ -1545,20 +1520,20 @@ jest-cli@^22.4.3:
     istanbul-lib-coverage "^1.1.1"
     istanbul-lib-instrument "^1.8.0"
     istanbul-lib-source-maps "^1.2.1"
-    jest-changed-files "^22.4.3"
-    jest-config "^22.4.3"
-    jest-environment-jsdom "^22.4.3"
-    jest-get-type "^22.4.3"
-    jest-haste-map "^22.4.3"
-    jest-message-util "^22.4.3"
-    jest-regex-util "^22.4.3"
-    jest-resolve-dependencies "^22.4.3"
-    jest-runner "^22.4.3"
-    jest-runtime "^22.4.3"
-    jest-snapshot "^22.4.3"
-    jest-util "^22.4.3"
-    jest-validate "^22.4.3"
-    jest-worker "^22.4.3"
+    jest-changed-files "^22.2.0"
+    jest-config "^22.4.4"
+    jest-environment-jsdom "^22.4.1"
+    jest-get-type "^22.1.0"
+    jest-haste-map "^22.4.2"
+    jest-message-util "^22.4.0"
+    jest-regex-util "^22.1.0"
+    jest-resolve-dependencies "^22.1.0"
+    jest-runner "^22.4.4"
+    jest-runtime "^22.4.4"
+    jest-snapshot "^22.4.0"
+    jest-util "^22.4.1"
+    jest-validate "^22.4.4"
+    jest-worker "^22.2.2"
     micromatch "^2.3.11"
     node-notifier "^5.2.1"
     realpath-native "^1.0.0"
@@ -1569,23 +1544,23 @@ jest-cli@^22.4.3:
     which "^1.2.12"
     yargs "^10.0.3"
 
-jest-config@^22.4.3:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-22.4.3.tgz#0e9d57db267839ea31309119b41dc2fa31b76403"
+jest-config@^22.4.4:
+  version "22.4.4"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-22.4.4.tgz#72a521188720597169cd8b4ff86934ef5752d86a"
   dependencies:
     chalk "^2.0.1"
     glob "^7.1.1"
-    jest-environment-jsdom "^22.4.3"
-    jest-environment-node "^22.4.3"
-    jest-get-type "^22.4.3"
-    jest-jasmine2 "^22.4.3"
-    jest-regex-util "^22.4.3"
-    jest-resolve "^22.4.3"
-    jest-util "^22.4.3"
-    jest-validate "^22.4.3"
-    pretty-format "^22.4.3"
+    jest-environment-jsdom "^22.4.1"
+    jest-environment-node "^22.4.1"
+    jest-get-type "^22.1.0"
+    jest-jasmine2 "^22.4.4"
+    jest-regex-util "^22.1.0"
+    jest-resolve "^22.4.2"
+    jest-util "^22.4.1"
+    jest-validate "^22.4.4"
+    pretty-format "^22.4.0"
 
-jest-diff@^22.4.3:
+jest-diff@^22.4.0, jest-diff@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-22.4.3.tgz#e18cc3feff0aeef159d02310f2686d4065378030"
   dependencies:
@@ -1594,13 +1569,13 @@ jest-diff@^22.4.3:
     jest-get-type "^22.4.3"
     pretty-format "^22.4.3"
 
-jest-docblock@^22.4.3:
+jest-docblock@^22.4.0, jest-docblock@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-22.4.3.tgz#50886f132b42b280c903c592373bb6e93bb68b19"
   dependencies:
     detect-newline "^2.1.0"
 
-jest-environment-jsdom@^22.4.3:
+jest-environment-jsdom@^22.4.1:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-22.4.3.tgz#d67daa4155e33516aecdd35afd82d4abf0fa8a1e"
   dependencies:
@@ -1608,18 +1583,18 @@ jest-environment-jsdom@^22.4.3:
     jest-util "^22.4.3"
     jsdom "^11.5.1"
 
-jest-environment-node@^22.4.3:
+jest-environment-node@^22.4.1:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-22.4.3.tgz#54c4eaa374c83dd52a9da8759be14ebe1d0b9129"
   dependencies:
     jest-mock "^22.4.3"
     jest-util "^22.4.3"
 
-jest-get-type@^22.4.3:
+jest-get-type@^22.1.0, jest-get-type@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-22.4.3.tgz#e3a8504d8479342dd4420236b322869f18900ce4"
 
-jest-haste-map@^22.4.3:
+jest-haste-map@^22.4.2:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-22.4.3.tgz#25842fa2ba350200767ac27f658d58b9d5c2e20b"
   dependencies:
@@ -1631,29 +1606,29 @@ jest-haste-map@^22.4.3:
     micromatch "^2.3.11"
     sane "^2.0.0"
 
-jest-jasmine2@^22.4.3:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-22.4.3.tgz#4daf64cd14c793da9db34a7c7b8dcfe52a745965"
+jest-jasmine2@^22.4.4:
+  version "22.4.4"
+  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-22.4.4.tgz#c55f92c961a141f693f869f5f081a79a10d24e23"
   dependencies:
     chalk "^2.0.1"
     co "^4.6.0"
-    expect "^22.4.3"
+    expect "^22.4.0"
     graceful-fs "^4.1.11"
     is-generator-fn "^1.0.0"
-    jest-diff "^22.4.3"
-    jest-matcher-utils "^22.4.3"
-    jest-message-util "^22.4.3"
-    jest-snapshot "^22.4.3"
-    jest-util "^22.4.3"
+    jest-diff "^22.4.0"
+    jest-matcher-utils "^22.4.0"
+    jest-message-util "^22.4.0"
+    jest-snapshot "^22.4.0"
+    jest-util "^22.4.1"
     source-map-support "^0.5.0"
 
-jest-leak-detector@^22.4.3:
+jest-leak-detector@^22.4.0:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-22.4.3.tgz#2b7b263103afae8c52b6b91241a2de40117e5b35"
   dependencies:
     pretty-format "^22.4.3"
 
-jest-matcher-utils@^22.4.3:
+jest-matcher-utils@^22.4.0, jest-matcher-utils@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz#4632fe428ebc73ebc194d3c7b65d37b161f710ff"
   dependencies:
@@ -1661,7 +1636,7 @@ jest-matcher-utils@^22.4.3:
     jest-get-type "^22.4.3"
     pretty-format "^22.4.3"
 
-jest-message-util@^22.4.3:
+jest-message-util@^22.4.0, jest-message-util@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-22.4.3.tgz#cf3d38aafe4befddbfc455e57d65d5239e399eb7"
   dependencies:
@@ -1675,56 +1650,56 @@ jest-mock@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-22.4.3.tgz#f63ba2f07a1511772cdc7979733397df770aabc7"
 
-jest-regex-util@^22.4.3:
+jest-regex-util@^22.1.0, jest-regex-util@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-22.4.3.tgz#a826eb191cdf22502198c5401a1fc04de9cef5af"
 
-jest-resolve-dependencies@^22.4.3:
+jest-resolve-dependencies@^22.1.0:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-22.4.3.tgz#e2256a5a846732dc3969cb72f3c9ad7725a8195e"
   dependencies:
     jest-regex-util "^22.4.3"
 
-jest-resolve@^22.4.3:
+jest-resolve@^22.4.2:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-22.4.3.tgz#0ce9d438c8438229aa9b916968ec6b05c1abb4ea"
   dependencies:
     browser-resolve "^1.11.2"
     chalk "^2.0.1"
 
-jest-runner@^22.4.3:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-22.4.3.tgz#298ddd6a22b992c64401b4667702b325e50610c3"
+jest-runner@^22.4.4:
+  version "22.4.4"
+  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-22.4.4.tgz#dfca7b7553e0fa617e7b1291aeb7ce83e540a907"
   dependencies:
     exit "^0.1.2"
-    jest-config "^22.4.3"
-    jest-docblock "^22.4.3"
-    jest-haste-map "^22.4.3"
-    jest-jasmine2 "^22.4.3"
-    jest-leak-detector "^22.4.3"
-    jest-message-util "^22.4.3"
-    jest-runtime "^22.4.3"
-    jest-util "^22.4.3"
-    jest-worker "^22.4.3"
+    jest-config "^22.4.4"
+    jest-docblock "^22.4.0"
+    jest-haste-map "^22.4.2"
+    jest-jasmine2 "^22.4.4"
+    jest-leak-detector "^22.4.0"
+    jest-message-util "^22.4.0"
+    jest-runtime "^22.4.4"
+    jest-util "^22.4.1"
+    jest-worker "^22.2.2"
     throat "^4.0.0"
 
-jest-runtime@^22.4.3:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-22.4.3.tgz#b69926c34b851b920f666c93e86ba2912087e3d0"
+jest-runtime@^22.4.4:
+  version "22.4.4"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-22.4.4.tgz#9ba7792fc75582a5be0f79af6f8fe8adea314048"
   dependencies:
     babel-core "^6.0.0"
-    babel-jest "^22.4.3"
+    babel-jest "^22.4.4"
     babel-plugin-istanbul "^4.1.5"
     chalk "^2.0.1"
     convert-source-map "^1.4.0"
     exit "^0.1.2"
     graceful-fs "^4.1.11"
-    jest-config "^22.4.3"
-    jest-haste-map "^22.4.3"
-    jest-regex-util "^22.4.3"
-    jest-resolve "^22.4.3"
-    jest-util "^22.4.3"
-    jest-validate "^22.4.3"
+    jest-config "^22.4.4"
+    jest-haste-map "^22.4.2"
+    jest-regex-util "^22.1.0"
+    jest-resolve "^22.4.2"
+    jest-util "^22.4.1"
+    jest-validate "^22.4.4"
     json-stable-stringify "^1.0.1"
     micromatch "^2.3.11"
     realpath-native "^1.0.0"
@@ -1737,7 +1712,7 @@ jest-serializer@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-22.4.3.tgz#a679b81a7f111e4766235f4f0c46d230ee0f7436"
 
-jest-snapshot@^22.4.3:
+jest-snapshot@^22.4.0:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-22.4.3.tgz#b5c9b42846ffb9faccb76b841315ba67887362d2"
   dependencies:
@@ -1748,7 +1723,7 @@ jest-snapshot@^22.4.3:
     natural-compare "^1.4.0"
     pretty-format "^22.4.3"
 
-jest-util@^22.4.3:
+jest-util@^22.4.1, jest-util@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-22.4.3.tgz#c70fec8eec487c37b10b0809dc064a7ecf6aafac"
   dependencies:
@@ -1760,36 +1735,36 @@ jest-util@^22.4.3:
     mkdirp "^0.5.1"
     source-map "^0.6.0"
 
-jest-validate@^22.4.3:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-22.4.3.tgz#0780954a5a7daaeec8d3c10834b9280865976b30"
+jest-validate@^22.4.4:
+  version "22.4.4"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-22.4.4.tgz#1dd0b616ef46c995de61810d85f57119dbbcec4d"
   dependencies:
     chalk "^2.0.1"
-    jest-config "^22.4.3"
-    jest-get-type "^22.4.3"
+    jest-config "^22.4.4"
+    jest-get-type "^22.1.0"
     leven "^2.1.0"
-    pretty-format "^22.4.3"
+    pretty-format "^22.4.0"
 
-jest-worker@^22.4.3:
+jest-worker@^22.2.2, jest-worker@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-22.4.3.tgz#5c421417cba1c0abf64bf56bd5fb7968d79dd40b"
   dependencies:
     merge-stream "^1.0.1"
 
 jest@^22.0.4:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/jest/-/jest-22.4.3.tgz#2261f4b117dc46d9a4a1a673d2150958dee92f16"
+  version "22.4.4"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-22.4.4.tgz#ffb36c9654b339a13e10b3d4b338eb3e9d49f6eb"
   dependencies:
     import-local "^1.0.0"
-    jest-cli "^22.4.3"
+    jest-cli "^22.4.4"
 
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
 js-yaml@^3.7.0:
-  version "3.11.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.11.0.tgz#597c1a8bd57152f26d622ce4117851a51f5ebaef"
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -1799,21 +1774,21 @@ jsbn@~0.1.0:
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
 
 jsdom@^11.5.1:
-  version "11.10.0"
-  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.10.0.tgz#a42cd54e88895dc765f03f15b807a474962ac3b5"
+  version "11.11.0"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.11.0.tgz#df486efad41aee96c59ad7a190e2449c7eb1110e"
   dependencies:
     abab "^1.0.4"
     acorn "^5.3.0"
     acorn-globals "^4.1.0"
     array-equal "^1.0.0"
     cssom ">= 0.3.2 < 0.4.0"
-    cssstyle ">= 0.2.37 < 0.3.0"
+    cssstyle ">= 0.3.1 < 0.4.0"
     data-urls "^1.0.0"
     domexception "^1.0.0"
     escodegen "^1.9.0"
     html-encoding-sniffer "^1.0.2"
     left-pad "^1.2.0"
-    nwmatcher "^1.4.3"
+    nwsapi "^2.0.0"
     parse5 "4.0.0"
     pn "^1.1.0"
     request "^2.83.0"
@@ -1825,7 +1800,7 @@ jsdom@^11.5.1:
     webidl-conversions "^4.0.2"
     whatwg-encoding "^1.0.3"
     whatwg-mimetype "^2.1.0"
-    whatwg-url "^6.4.0"
+    whatwg-url "^6.4.1"
     ws "^4.0.0"
     xml-name-validator "^3.0.0"
 
@@ -1934,7 +1909,7 @@ lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
 
-lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.4:
+lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.4:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
@@ -1949,8 +1924,8 @@ loose-envify@^1.0.0:
     js-tokens "^3.0.0"
 
 lru-cache@^4.0.1:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.2.tgz#45234b2e6e2f2b33da125624c4664929a0224c3f"
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.3.tgz#a1175cf3496dfc8436c156c334b4955992bce69c"
   dependencies:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
@@ -1970,6 +1945,10 @@ map-visit@^1.0.0:
   resolved "https://registry.yarnpkg.com/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
   dependencies:
     object-visit "^1.0.0"
+
+math-random@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/math-random/-/math-random-1.0.1.tgz#8b3aac588b8a66e4975e3cdea67f7bb329601fac"
 
 mem@^1.1.0:
   version "1.1.0"
@@ -2055,11 +2034,11 @@ minimist@~0.0.1:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
-minipass@^2.2.1, minipass@^2.2.4:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.2.4.tgz#03c824d84551ec38a8d1bb5bc350a5a30a354a40"
+minipass@^2.2.1, minipass@^2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.3.3.tgz#a7dcc8b7b833f5d368759cce544dccb55f50f233"
   dependencies:
-    safe-buffer "^5.1.1"
+    safe-buffer "^5.1.2"
     yallist "^3.0.0"
 
 minizlib@^1.1.0:
@@ -2138,9 +2117,9 @@ node-notifier@^5.2.1:
     shellwords "^0.1.1"
     which "^1.3.0"
 
-node-pre-gyp@^0.9.0:
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.9.1.tgz#f11c07516dd92f87199dbc7e1838eab7cd56c9e0"
+node-pre-gyp@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.10.0.tgz#6e4ef5bb5c5203c6552448828c852c40111aac46"
   dependencies:
     detect-libc "^1.0.2"
     mkdirp "^0.5.1"
@@ -2205,9 +2184,9 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
-nwmatcher@^1.4.3:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/nwmatcher/-/nwmatcher-1.4.4.tgz#2285631f34a95f0d0395cd900c96ed39b58f346e"
+nwsapi@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.0.1.tgz#a50d59a2dcb14b6931401171713ced2d0eb3468f"
 
 oauth-sign@~0.8.2:
   version "0.8.2"
@@ -2415,7 +2394,7 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-pretty-format@^22.4.3:
+pretty-format@^22.4.0, pretty-format@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-22.4.3.tgz#f873d780839a9c02e9664c8a082e9ee79eaac16f"
   dependencies:
@@ -2434,30 +2413,35 @@ pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
+psl@^1.1.24:
+  version "1.1.27"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.27.tgz#2b2c77019db86855170d903532400bf71ee085b6"
+
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
 punycode@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.0.tgz#5f863edc89b96db09074bad7947bf09056ca4e7d"
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
 
 qs@~6.5.1:
-  version "6.5.1"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
 
-randomatic@^1.1.3:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.7.tgz#c7abe9cc8b87c0baa876b19fde83fd464797e38c"
+randomatic@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-3.0.0.tgz#d35490030eb4f7578de292ce6dfb04a91a128923"
   dependencies:
-    is-number "^3.0.0"
-    kind-of "^4.0.0"
+    is-number "^4.0.0"
+    kind-of "^6.0.0"
+    math-random "^1.0.1"
 
 rc@^1.1.7:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.7.tgz#8a10ca30d588d00464360372b890d06dacd02297"
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   dependencies:
-    deep-extend "^0.5.1"
+    deep-extend "^0.6.0"
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
@@ -2545,8 +2529,8 @@ request-promise-native@^1.0.5:
     tough-cookie ">=2.3.3"
 
 request@^2.83.0:
-  version "2.85.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.85.0.tgz#5a03615a47c61420b3eb99b7dba204f83603e1fa"
+  version "2.87.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.87.0.tgz#32f00235cd08d482b4d0d68db93a829c0ed5756e"
   dependencies:
     aws-sign2 "~0.7.0"
     aws4 "^1.6.0"
@@ -2556,7 +2540,6 @@ request@^2.83.0:
     forever-agent "~0.6.1"
     form-data "~2.3.1"
     har-validator "~5.0.3"
-    hawk "~6.0.2"
     http-signature "~1.2.0"
     is-typedarray "~1.0.0"
     isstream "~0.1.2"
@@ -2566,7 +2549,6 @@ request@^2.83.0:
     performance-now "^2.1.0"
     qs "~6.5.1"
     safe-buffer "^5.1.1"
-    stringstream "~0.0.5"
     tough-cookie "~2.3.3"
     tunnel-agent "^0.6.0"
     uuid "^3.1.0"
@@ -2613,6 +2595,10 @@ rimraf@^2.5.4, rimraf@^2.6.1:
   dependencies:
     glob "^7.0.5"
 
+rsvp@^3.3.3:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.6.2.tgz#2e96491599a96cde1b515d5674a8f7a91452926a"
+
 safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
@@ -2623,15 +2609,16 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
-safer-buffer@^2.1.0:
+"safer-buffer@>= 2.1.2 < 3":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
 
 sane@^2.0.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/sane/-/sane-2.5.0.tgz#6359cd676f5efd9988b264d8ce3b827dd6b27bec"
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/sane/-/sane-2.5.2.tgz#b4dc1861c21b427e929507a3e751e2a2cb8ab3fa"
   dependencies:
     anymatch "^2.0.0"
+    capture-exit "^1.2.0"
     exec-sh "^0.2.0"
     fb-watchman "^2.0.0"
     micromatch "^3.1.4"
@@ -2639,7 +2626,7 @@ sane@^2.0.0:
     walker "~1.0.5"
     watch "~0.18.0"
   optionalDependencies:
-    fsevents "^1.1.1"
+    fsevents "^1.2.3"
 
 sax@^1.2.4:
   version "1.2.4"
@@ -2720,17 +2707,11 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
-sntp@2.x.x:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/sntp/-/sntp-2.1.0.tgz#2c6cec14fedc2222739caf9b5c3d85d1cc5a2cc8"
-  dependencies:
-    hoek "4.x.x"
-
 source-map-resolve@^0.5.0:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.1.tgz#7ad0f593f2281598e854df80f19aae4b92d7a11a"
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.2.tgz#72e2cc34095543e43b2c62b2c4c10d4a9054f259"
   dependencies:
-    atob "^2.0.0"
+    atob "^2.1.1"
     decode-uri-component "^0.2.0"
     resolve-url "^0.2.1"
     source-map-url "^0.4.0"
@@ -2743,8 +2724,8 @@ source-map-support@^0.4.15:
     source-map "^0.5.6"
 
 source-map-support@^0.5.0:
-  version "0.5.5"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.5.tgz#0d4af9e00493e855402e8ec36ebed2d266fceb90"
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.6.tgz#4435cee46b1aab62b8e8610ce60f788091c51c13"
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
@@ -2835,7 +2816,7 @@ string-length@^2.0.0:
     astral-regex "^1.0.0"
     strip-ansi "^4.0.0"
 
-string-width@^1.0.1, string-width@^1.0.2:
+string-width@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
   dependencies:
@@ -2843,7 +2824,7 @@ string-width@^1.0.1, string-width@^1.0.2:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-string-width@^2.0.0, string-width@^2.1.1:
+"string-width@^1.0.2 || 2", string-width@^2.0.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   dependencies:
@@ -2855,10 +2836,6 @@ string_decoder@~1.1.1:
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
   dependencies:
     safe-buffer "~5.1.0"
-
-stringstream@~0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.5.tgz#4e484cd4de5a0bbbee18e46307710a8a81621878"
 
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
@@ -2911,12 +2888,12 @@ symbol-tree@^3.2.2:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
 
 tar@^4:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.2.tgz#60685211ba46b38847b1ae7ee1a24d744a2cd462"
+  version "4.4.4"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.4.tgz#ec8409fae9f665a4355cc3b4087d0820232bb8cd"
   dependencies:
     chownr "^1.0.1"
     fs-minipass "^1.2.5"
-    minipass "^2.2.4"
+    minipass "^2.3.3"
     minizlib "^1.1.0"
     mkdirp "^0.5.0"
     safe-buffer "^5.1.2"
@@ -2966,7 +2943,14 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
-tough-cookie@>=2.3.3, tough-cookie@^2.3.3, tough-cookie@~2.3.3:
+tough-cookie@>=2.3.3, tough-cookie@^2.3.3:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.4.2.tgz#aa9133154518b494efab98a58247bfc38818c00c"
+  dependencies:
+    psl "^1.1.24"
+    punycode "^1.4.1"
+
+tough-cookie@~2.3.3:
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.4.tgz#ec60cee38ac675063ffc97a5c18970578ee83655"
   dependencies:
@@ -3100,7 +3084,7 @@ whatwg-mimetype@^2.0.0, whatwg-mimetype@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.1.0.tgz#f0f21d76cbba72362eb609dbed2a30cd17fcc7d4"
 
-whatwg-url@^6.4.0:
+whatwg-url@^6.4.0, whatwg-url@^6.4.1:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.4.1.tgz#fdb94b440fd4ad836202c16e9737d511f012fd67"
   dependencies:
@@ -3113,16 +3097,16 @@ which-module@^2.0.0:
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
 
 which@^1.2.12, which@^1.2.9, which@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   dependencies:
     isexe "^2.0.0"
 
 wide-align@^1.1.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.2.tgz#571e0f1b0604636ebc0dfc21b0339bbe31341710"
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.3.tgz#ae074e6bdc0c14a431e804e624549c633b000457"
   dependencies:
-    string-width "^1.0.2"
+    string-width "^1.0.2 || 2"
 
 window-size@0.1.0:
   version "0.1.0"

--- a/test/interface/golden/yarn.lock
+++ b/test/interface/golden/yarn.lock
@@ -16,7 +16,7 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-"@glennsl/bs-jest@^0.4.1", "@glennsl/bs-jest@^0.4.2":
+"@glennsl/bs-jest@^0.4.2":
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/@glennsl/bs-jest/-/bs-jest-0.4.2.tgz#c8bd899aca0feae5927f4778cbdeb4c46bb2eef9"
   dependencies:
@@ -412,17 +412,17 @@ browser-resolve@^1.11.2:
   dependencies:
     resolve "1.1.7"
 
-bs-aeson-spec@^1.2.1:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/bs-aeson-spec/-/bs-aeson-spec-1.2.2.tgz#769aff006e6ee90f6db102a89dec19293ed39dba"
+bs-aeson-spec@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/bs-aeson-spec/-/bs-aeson-spec-2.0.0.tgz#a9f10a20f4d4a6ed18d4073c21fa09effe60ec2c"
   dependencies:
     "@glennsl/bs-jest" "^0.4.2"
-    bs-aeson "^1.1.0"
+    bs-aeson "^2.0.0"
     bs-node-fetch "^0.1.2"
 
-bs-aeson@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/bs-aeson/-/bs-aeson-1.1.0.tgz#8755b27c18fed55f9ebf197984b6ef414d5a85f3"
+bs-aeson@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/bs-aeson/-/bs-aeson-2.0.0.tgz#ec6d2198cbbd626c9ecf0a1fdc03ce10c96bdbfc"
 
 bs-node-fetch@^0.1.2:
   version "0.1.2"
@@ -434,9 +434,9 @@ bs-node-fetch@^0.1.2:
   version "0.0.1"
   resolved "https://codeload.github.com/buckletypes/bs-node/tar.gz/20ef6d2d7c00e923aba33b0629ca5623a4460712"
 
-bs-platform@^2.2.0:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-2.2.3.tgz#d905ae10a5f3621e6a739041dfa0b58483a2174f"
+bs-platform@^3.1.3:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-3.1.4.tgz#fe8495443b35aff73dfb61cba1e6d7b88311910b"
 
 bser@^2.0.0:
   version "2.0.0"

--- a/test/interface/golden/yarn.lock
+++ b/test/interface/golden/yarn.lock
@@ -424,6 +424,10 @@ bs-aeson@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/bs-aeson/-/bs-aeson-2.0.0.tgz#ec6d2198cbbd626c9ecf0a1fdc03ce10c96bdbfc"
 
+"bs-aeson@github:plow-technologies/bs-aeson#8eed965c4841c5788ebf40a22c7df3aafcaa5749":
+  version "3.0.0"
+  resolved "https://codeload.github.com/plow-technologies/bs-aeson/tar.gz/8eed965c4841c5788ebf40a22c7df3aafcaa5749"
+
 bs-node-fetch@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/bs-node-fetch/-/bs-node-fetch-0.1.2.tgz#0e86af872083ddb28d9db357f4701a1891e8823e"

--- a/test/ocaml/Business.ml
+++ b/test/ocaml/Business.ml
@@ -21,5 +21,5 @@ let decodeBusiness json =
     ; companyVehicle = optional (field "companyVehicle" (fun a -> unwrapResult (decodeAutomobile a))) json
     }
   with
-  | v -> Js_result.Ok v
-  | exception Aeson.Decode.DecodeError message -> Js_result.Error ("decodeBusiness: " ^ message)
+  | v -> Belt.Result.Ok v
+  | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("decodeBusiness: " ^ message)

--- a/test/ocaml/Business.mli
+++ b/test/ocaml/Business.mli
@@ -7,4 +7,4 @@ type business =
 
 val encodeBusiness : business -> Js_json.t
 
-val decodeBusiness : Js_json.t -> (business, string) Js_result.t
+val decodeBusiness : Js_json.t -> (business, string) Belt.Result.t

--- a/test/ocaml/NonGenericType.ml
+++ b/test/ocaml/NonGenericType.ml
@@ -15,5 +15,5 @@ let decodeNonGenericType json =
         ; ngB = field "ngB" int json
         }
   with
-  | v -> Js_result.Ok v
-  | exception Aeson.Decode.DecodeError message -> Js_result.Error ("decodeNonGenericType: " ^ message)
+  | v -> Belt.Result.Ok v
+  | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("decodeNonGenericType: " ^ message)

--- a/test/ocaml/NonGenericType.mli
+++ b/test/ocaml/NonGenericType.mli
@@ -5,4 +5,4 @@ type nonGenericType =
 
 val encodeNonGenericType : nonGenericType -> Js_json.t
 
-val decodeNonGenericType : Js_json.t -> (nonGenericType, string) Js_result.t
+val decodeNonGenericType : Js_json.t -> (nonGenericType, string) Belt.Result.t

--- a/test/ocaml/Person.ml
+++ b/test/ocaml/Person.ml
@@ -15,5 +15,5 @@ let decodePerson json =
     ; name = optional (field "name" string) json
     }
   with
-  | v -> Js_result.Ok v
-  | exception Aeson.Decode.DecodeError message -> Js_result.Error ("decodePerson: " ^ message)
+  | v -> Belt.Result.Ok v
+  | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("decodePerson: " ^ message)

--- a/test/ocaml/Person.mli
+++ b/test/ocaml/Person.mli
@@ -5,4 +5,4 @@ type person =
 
 val encodePerson : person -> Js_json.t
 
-val decodePerson : Js_json.t -> (person, string) Js_result.t
+val decodePerson : Js_json.t -> (person, string) Belt.Result.t

--- a/test/ocaml/Simple.ml
+++ b/test/ocaml/Simple.ml
@@ -15,5 +15,5 @@ let decodeSimple json =
     ; sb = field "sb" string json
     }
   with
-  | v -> Js_result.Ok v
-  | exception Aeson.Decode.DecodeError message -> Js_result.Error ("decodeSimple: " ^ message)
+  | v -> Belt.Result.Ok v
+  | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("decodeSimple: " ^ message)

--- a/test/ocaml/Simple.mli
+++ b/test/ocaml/Simple.mli
@@ -5,4 +5,4 @@ type simple =
 
 val encodeSimple : simple -> Js_json.t
 
-val decodeSimple : Js_json.t -> (simple, string) Js_result.t
+val decodeSimple : Js_json.t -> (simple, string) Belt.Result.t

--- a/test/ocaml/Wrapper.ml
+++ b/test/ocaml/Wrapper.ml
@@ -18,5 +18,5 @@ let decodeWrapper a b json =
         ; wrapperC = field "wrapperC" string json
         }
   with
-  | v -> Js_result.Ok v
-  | exception Aeson.Decode.DecodeError message -> Js_result.Error ("decodeWrapper: " ^ message)
+  | v -> Belt.Result.Ok v
+  | exception Aeson.Decode.DecodeError message -> Belt.Result.Error ("decodeWrapper: " ^ message)

--- a/test/ocaml/Wrapper.mli
+++ b/test/ocaml/Wrapper.mli
@@ -6,4 +6,4 @@ type ('a, 'b) wrapper =
 
 val encodeWrapper : ('a -> Js_json.t) -> ('b -> Js_json.t) -> ('a, 'b) wrapper -> Js_json.t
 
-val decodeWrapper : (Js_json.t -> ('a, string) Js_result.t) -> (Js_json.t -> ('b, string) Js_result.t) -> Js_json.t -> (('a, 'b) wrapper, string) Js_result.t
+val decodeWrapper : (Js_json.t -> ('a, string) Belt.Result.t) -> (Js_json.t -> ('b, string) Belt.Result.t) -> Js_json.t -> (('a, 'b) wrapper, string) Belt.Result.t


### PR DESCRIPTION
* Output BuckleScript code requires at least BuckleScript 3.1.0.
* Change output BuckleScript code and test code to use `Belt.Result.t` instead of `Js.Result.t`. `Js.Result.t` has been deprecated since BuckleScript 3.1.0.
* Add `OInt32` to `OCaml.BuckleScript.Types.OCamlPrimitive` to convert Haskell `Int32` to BuckleScript `int32`.

# Link to specification or issue number

#  Focus areas

#  UI Screenshots

# Tasks for PR creator

* [x]  Change Version

* [x]  Changelog entry
* [ ]  Note Serialization changes in changelog

* [ ] Header comments

* [ ] Justify existence per function/per module


##  Check warning flags are on
* [ ]  -werror
* [ ]  -wall
* [ ]  - -Wincomplete-uni-patterns
* [ ]  - -Wincomplete-record-updates
* [ ]  Check tests are on
* [ ]  Check documentation is being generated

# Tasks for PR reviewer
* [ ]  Check for dropped errors
* [ ]  Ask about focus areas
* [ ]  Check import qualifications
* [ ]  Check module exports
* [ ]  Check for readability of variables and other names